### PR TITLE
Dashboard: Adds annotations for letsencrypt-staging certificate and gardener dns management

### DIFF
--- a/hack/dev-env/config/dashboard-values.yaml
+++ b/hack/dev-env/config/dashboard-values.yaml
@@ -6,6 +6,12 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: |
+    ingress:
+      annotations:
+        dns.gardener.cloud/dnsnames: dashboard.${ENV}.${BASE_DOMAIN}
+        dns.gardener.cloud/ttl: "500"
+        dns.gardener.cloud/class: garden
+        cert-manager.io/cluster-issuer: letsencrypt-staging
     oidc:
       ca: |
         -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Signed-off-by: Malte Münch <muench@23technologies.cloud>
