### PR TITLE
Bump dexidp image from v2.27.0 to v2.30.0

### DIFF
--- a/helmcharts/identity/values.yaml
+++ b/helmcharts/identity/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/dexidp/dex
-  tag: v2.27.0
+  tag: v2.30.0
   pullPolicy: IfNotPresent
 
 containerPort: 5556


### PR DESCRIPTION
Signed-off-by: Malte Münch <muench@23technologies.cloud>
