### PR TITLE
Rename le-staging issuer to default issuer.

### DIFF
--- a/hack/ci/dev-env/config/cert-management-values.yaml
+++ b/hack/ci/dev-env/config/cert-management-values.yaml
@@ -10,5 +10,4 @@ stringData:
       issuers: false
       certificates: false
     configuration:
-      defaultIssuer: le-staging-issuer
       defaultIssuerDomainRanges: internal.${AZURE_DOMAIN}

--- a/pre-gardener/cert-management/cert-management-base-values.yaml
+++ b/pre-gardener/cert-management/cert-management-base-values.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   values.yaml: |-
     configuration:
+      defaultIssuer: default-issuer
       certClass: base-cert-class
       issuerNamespace: garden
       dnsClass: base-dns-class

--- a/pre-gardener/issuer/chart/templates/issuer.yaml
+++ b/pre-gardener/issuer/chart/templates/issuer.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: Issuer
 metadata:
-  name: le-staging-issuer
+  name: default-issuer
   namespace: garden
   annotations:
     cert.gardener.cloud/class: base-cert-class


### PR DESCRIPTION
Now it's only up to the user to input a valid issuer url and not the
name of the default issuer

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>