### PR TITLE
remove quotes around nginx dnsnames annotation used for wildcard cert

### DIFF
--- a/pre-gardener/ingress-nginx/ingress-nginx-base-values.yaml
+++ b/pre-gardener/ingress-nginx/ingress-nginx-base-values.yaml
@@ -11,7 +11,7 @@ data:
           cert.gardener.cloud/class: base-cert-class
           cert.gardener.cloud/secretname: controlplane-cert-secret
           dns.gardener.cloud/dnsnames: >-
-            "*.${GARDENLET_INGRESS:=internal}.${ENV}.${BASE_DOMAIN}"
+            *.${GARDENLET_INGRESS:=internal}.${ENV}.${BASE_DOMAIN}
           dns.gardener.cloud/ttl: "600"
           dns.gardener.cloud/class: base-dns-class
       extraArgs:


### PR DESCRIPTION
Fixes weird behavior introduced with #364 producing double quotes like `dns.gardener.cloud/dnsnames: '"*.internal.23ke-run-d135.23ke-testbed.23t.dev"'`