### PR TITLE
CI: Don't exit delete-scripts on errors

### DIFF
--- a/hack/ci/delete-microservice-shoot.sh
+++ b/hack/ci/delete-microservice-shoot.sh
@@ -4,9 +4,8 @@ set -euo pipefail
 source hack/ci/handy.sh
 
 echo "Deleting microservice"
-kubectl delete -n default -f hack/ci/misc/microservices-demo.yaml --kubeconfig hack/ci/secrets/shoot-microservice-kubeconfig.yaml --wait
+kubectl delete -n default -f hack/ci/misc/microservices-demo.yaml --kubeconfig hack/ci/secrets/shoot-microservice-kubeconfig.yaml --wait || echo "There was an error deleting the microservice"
 
 echo "Deleting demo shoot"
-kubectl annotate shoot -n garden-testing microservice confirmation.gardener.cloud/deletion=true --context garden --overwrite=true
-kubectl delete shoot -n garden-testing microservice --wait=true --context garden
-echo "Demo shoot deleted ✅"
+kubectl annotate shoot -n garden-testing microservice confirmation.gardener.cloud/deletion=true --context garden --overwrite=true || echo "There was an error annotating the demo shoot"
+kubectl delete shoot -n garden-testing microservice --wait=true --context garden || echo "There was an error deleting the demo shoot"

--- a/hack/ci/delete-shoot.sh
+++ b/hack/ci/delete-shoot.sh
@@ -4,11 +4,10 @@ set -euo pipefail
 source hack/ci/handy.sh
 
 # delete buckets on azure
-rclone -q purge $REMOTE:$BUCKET
-rclone -q purge $REMOTE:$CONFIG_BUCKET
+rclone -q purge $REMOTE:$BUCKET || echo "Deleting bucket failed"
+rclone -q purge $REMOTE:$CONFIG_BUCKET || echo "Deleting config bucket failed"
 
 echo "Deleting shoot"
 export KUBECONFIG=hack/ci/secrets/gardener-kubeconfig.yaml
-kubectl annotate shoot "$SHOOT" confirmation.gardener.cloud/deletion=true --overwrite=true
-kubectl delete shoot "$SHOOT" --wait=false
-echo "Shoot will be deleted in the background ✅"
+kubectl annotate shoot "$SHOOT" confirmation.gardener.cloud/deletion=true --overwrite=true || echo "Annotating shoot failed"
+kubectl delete shoot "$SHOOT" --wait=false || echo "Deleting shoot failed"


### PR DESCRIPTION
Due to `set -e` the scripts exit immediately on any non-zero exit code. Removing it would cause lines to fail silently, so just echoing a message per command seems reasonable. Also keeping `set -e` enforces this in a way.

fix #365 