### PR TITLE
update actions/checkout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/shoot-from-scratch.yaml
+++ b/.github/workflows/shoot-from-scratch.yaml
@@ -27,7 +27,7 @@ jobs:
       ZONE: ${{ github.event.inputs.zone }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       - name: Setup Environment

--- a/.github/workflows/yaml-syntax-check.yml
+++ b/.github/workflows/yaml-syntax-check.yml
@@ -11,7 +11,7 @@ jobs:
   check-yaml-syntax:
     runs-on: 23ke-default
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Jan Lohage <lohage@23technologies.cloud>