### PR TITLE
Add script+action for handling git-side of release process

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,27 @@
+name: Prepare release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version to be released. Format: 1.3.3-7'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: 23ke-runner
+    name: Release
+    env:
+      version: ${{ github.event.inputs.version }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config user.name "23T"
+          git config user.email operations@23technologies.cloud
+      - name: Prepare release
+        run: hack/prepare-release.sh "${{ env.version }}"

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -2,25 +2,69 @@
 
 set -eo pipefail
 
+_fail() {
+  msg=$1
+  prefix=""
+  if [ "$GITHUB_ACTIONS" == "true" ]; then
+    prefix="::error::"
+  fi
+
+  echo "$prefix$msg"
+  exit 1
+}
+
 minorPattern='^[0-9]{1,}[.][0-9]{1,}'
 versionPattern='^[0-9]{1,}[.][0-9]{1,}[.][0-9]{1,}-[0-9]{1,}$'
 
-version=$1
+version=${version:-$1}
 
 if [[ ! -d .git ]]; then
-  echo "script must be run from the repository root"
-  exit 1
+  _fail "script must be run from the repository root"
 fi
 
 if [[ ! $version =~ $versionPattern ]]; then
-  echo "usage: $0 1.2.3-4"
-  exit 1
+  _fail "usage: $0 1.2.3-4"
 fi
 
-minor=$(echo "$version" | grep -nE "$minorPattern")
-echo "Updating chart versions to $0"
-for chart in $(find . -name Chart.yaml); do
-  echo $chart
+minor=$(echo "$version" | grep -oE "$minorPattern")
+releaseNotes="release-notes/v$minor.md"
+
+tag="v$version"
+branch="release-v$minor"
+
+git fetch
+git fetch --tags
+
+if [[ -e ".git/refs/tags/$tag" ]]; then
+  _fail "A tag named '$tag' already exists."
+fi
+
+if [[ ! -f "$releaseNotes" ]]; then
+  _fail "No release notes found for version $minor. Expected file '$releaseNotes' to exist."
+fi
+
+if [[ $(grep "$branch" .github/renovate.json5 | wc -l) == "0" ]]; then
+  # todo: update renovate.json5 automatically
+
+  _fail "It seems you haven't set up .github/renovate.json5 to track the new version's release branch ($branch). Please do so."
+fi
+
+if [[ -e ".git/refs/remotes/origin/$branch" ]]; then
+  git switch "$branch"
+  git pull
+else
+  git switch -c "$branch"
+fi
+
+echo "Updating chart versions to $version"
+while read -r chart; do
+  echo "$chart"
   sed -i -r -e "s;^version:.+$;version: $version;" "$chart"
-done
+done <<< "$(find . -name Chart.yaml)"
 echo "Done"
+
+git add .
+git commit -m "$tag"
+git tag "$tag"
+git push -u origin "$branch"
+git push -u origin "$tag"


### PR DESCRIPTION
In order to make the release process less error-prone, releases should be created by manually invoking https://github.com/23technologies/23ke/actions/workflows/prepare-release.yaml rather than tagging releases manually.

- Validates version format
- Creates release branch if needed
- Checks if release branch exists in renovate config
- Checks if release notes exist
- Syncs helm chart versions with release version

Signed-off-by: Jan Lohage <lohage@23technologies.cloud>