### PR TITLE
Move vpa addons under pre-gardener/addons

### DIFF
--- a/gardener/configuration/templates/garden-content-base-values.yaml
+++ b/gardener/configuration/templates/garden-content-base-values.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garden-content-base-values
+  namespace: flux-system
+type: Opaque
+stringData:
+  values.yaml: |-
+    backups:
+      {{- toYaml .Values.backups | nindent 6 }}

--- a/gardener/garden-content.yaml
+++ b/gardener/garden-content.yaml
@@ -20,5 +20,5 @@ spec:
       interval: 1m
   valuesFrom:
     - kind: Secret
-      name: 23ke-config
+      name: garden-content-base-values
       optional: false

--- a/pre-gardener/addons.yaml
+++ b/pre-gardener/addons.yaml
@@ -15,4 +15,7 @@ spec:
       interval: 1m
   valuesFrom:
     - kind: Secret
-      name: 23ke-config
+      name: addons-base-values
+    - kind: Secret
+      name: addons-values
+      optional: true

--- a/pre-gardener/addons/Chart.yaml
+++ b/pre-gardener/addons/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: extensions
-description: A Helm chart for the velero backups
+description: A Helm chart for addons to install with the pre-gardener ks
 
 type: application
 
-version: 0.0.15
+version: 0.0.1

--- a/pre-gardener/addons/templates/vpa-v1-crd-gen.yaml
+++ b/pre-gardener/addons/templates/vpa-v1-crd-gen.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vpa.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -755,3 +756,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/pre-gardener/addons/values.yaml
+++ b/pre-gardener/addons/values.yaml
@@ -1,0 +1,4 @@
+backups:
+  enabled: false
+vpa:
+  enabled: false

--- a/pre-gardener/configuration/templates/addons-base-values.yaml
+++ b/pre-gardener/configuration/templates/addons-base-values.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: addons-base-values
+  namespace: flux-system
+type: Opaque
+stringData:
+  values.yaml: |-
+    backups:
+      {{- toYaml .Values.backups | nindent 6 }}


### PR DESCRIPTION
The vpa-crds will be installed when enabled in the secret
addons-values in the environment specific configuration repository.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>