### PR TITLE
Release action: Allow empty commits for tagging

### DIFF
--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -70,7 +70,7 @@ else
 fi
 
 git add .
-git commit -m "$tag"
+git commit --allow-empty -m "$tag"
 git tag "$tag"
 git push -u origin "$branch"
 git push -u origin "$tag"


### PR DESCRIPTION
since we're not setting chart-versions on release any longer, just create an empty commit, to keep version tagging consistent