### PR TITLE
default backups.enabled to false in configuration chart

### DIFF
--- a/pre-gardener/configuration/values.yaml
+++ b/pre-gardener/configuration/values.yaml
@@ -2,6 +2,9 @@ clusterIdentity: garden-cluster-identity
 gardenlet:
   ingressDomain: internal
 
+backups:
+  enabled: false
+
 domains:
   global:
     domain: "example.org"


### PR DESCRIPTION
If 23ke-config secret did not contain any "backups" block (which did not exist in previous versions), the addons-base-values secret then contained

```
values.yaml: |-
  backups:
    null
```
because of the way the template is written, and the addons hr was be unhappy with that input.

The alternative would be to write the templates with more "if"s to check if values are present. For this particular case, "backups are not enabled" feels like a reasonable and explicit default to just define in values.yaml.