### PR TITLE
add global.image.tag: {{ $v.version }} for admission

### DIFF
--- a/gardener/helmcharts/extensions-meta-chart/templates/helmrelease-admission.yaml
+++ b/gardener/helmcharts/extensions-meta-chart/templates/helmrelease-admission.yaml
@@ -31,7 +31,7 @@ spec:
   values:
     global:
       image:
-        tag: {{ $v.version }}
+        tag: v{{ $v.version }}
       virtualGarden:
         enabled: true
     gardener-extension-admission-{{ $extShortName }}:
@@ -71,7 +71,7 @@ spec:
   values:
     global:
       image:
-        tag: {{ $v.version }}
+        tag: v{{ $v.version }}
       virtualGarden:
         enabled: true
     gardener-extension-admission-{{ $extShortName }}:


### PR DESCRIPTION
To overwrite "tag: latest" from upstream.

This could also be fixed in the chart-releaser with special handling for every admission chart, but I did not feel like adding so many more cases to that switch c.Name() ...

So I propose to fix it in this way for now.