### PR TITLE
ci/shoot: fetch github host keys at setup time

### DIFF
--- a/.github/workflows/shoot-from-scratch.yaml
+++ b/.github/workflows/shoot-from-scratch.yaml
@@ -43,6 +43,11 @@ jobs:
           retry_wait_seconds: 30
           retry_on: error
           command: |
+            # actually defeats the purpose of host keys
+            # including the actual keys would be more secure
+            mkdir -p ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+
             echo "${{ secrets.TOKEN_OKEANOS_23KE_CI }}" \
               > hack/ci/secrets/gardener-kubeconfig.yaml
             bash hack/ci/00-environment.sh


### PR DESCRIPTION
23kectl needs them to be present

Signed-off-by: Jan Lohage <lohage@23technologies.cloud>