### PR TITLE
Upload also to the release repo when releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,11 +62,16 @@ jobs:
           for file in $(grep --exclude-dir=hack --exclude-dir=flux-system -lr GitRepository . | sed 's/^\.\///'); do
             cat $file | sed s/GitRepository/Bucket/ | mc pipe "$MC_ALIAS/$tag/$file"
           done
+      - name: Checkout 23ke-releases repo
+        uses: actions/checkout@v3
+        with:
+          repository: 23technologies/23ke-releases
+          path: 23ke-releases
+          token: "${{ secrets.GH_TOKEN_23T_MACHINE_USER }}"
       - name: Upload to release git repository
         env:
           tag: v${{ github.event.inputs.version }}
         run: |
-          git clone git@github.com:23technologies/23ke-releases.git
 
           cp kustomization.yaml 23ke-releases
           cp -r flux-system 23ke-releases


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

We need to releaes to a repository also, as this is useful for environments in which working with git is easier than working with buckets. I am not sure, whether the git clone via ssh will work for the 23t-machine-user. Can anyone enlighten me here?