### PR TITLE
Keep renovate from rebasing forever / enable rebasing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,13 +9,13 @@
     "release-v1.61",
     "release-v1.60",
   ],
-  "automerge": "true",
+  "automerge": true,
   "dependencyDashboard": true,
-  "platformAutomerge": "true",
+  "platformAutomerge": true,
   "prHourlyLimit": 0,
   "prConcurrentLimit": 1,
   "flux": {
-			"fileMatch": ["pre-gardener/.*.yaml", "gardener/.*.yaml", "flux-system/gotk-components.yaml"]
+	"fileMatch": ["pre-gardener/.*.yaml", "gardener/.*.yaml", "flux-system/gotk-components.yaml"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
To determine if a branch is in conflict with its base branch, renovate runs `git merge --no-commit -no-ff <feature-branch>`. On error it reapplies all of its updated to the latest base branch commit and force-pushes to the feature branch to resolve the conflict.

If a post upgrade task creates extra (i.e. unstaged) files, `git merge` can fail. Renovate will see a need to rebase and force-push to the feature branch without solving the actual problem. Thus it keeps rebasing for all eternity.

Staging pulled files will prevent this (for our case).