### PR TITLE
Fix OCI upload to harbor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,11 +36,7 @@ jobs:
         with:
           token: "${{ secrets.GH_TOKEN_23T_MACHINE_USER }}"
           ref: "v${{ github.event.inputs.version }}"
-      - name: Install MC
-        run: |
-          mkdir -p ~/.local/bin
-          wget https://dl.minio.io/client/mc/release/linux-amd64/mc -O ~/.local/bin/mc
-          chmod +x ~/.local/bin/mc
+
       - name: Upload to release bucket
         env:
           MINIO_HOSTNAME: ${{ secrets.MINIOHOSTNAME }}
@@ -54,20 +50,13 @@ jobs:
           tmpDir=$(hack/make-tmp-release-dir.sh Bucket)
           mc cp --recursive $tmpDir/* "$MC_ALIAS/$tag"
       
-      - name: Install Flux
-        run: |
-          export FLUX_VERSION=0.39.0
-          mkdir -p ~/.local/bin
-          wget -O - "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" \
-            | tar -xzC ~/.local/bin
-          chmod +x ~/.local/bin/flux
       - name: Upload to harbor container registry
         env:
           tag: v${{ github.event.inputs.version }}
           creds: ${{ secrets.HARBORCREDENTIALS }}
         run: |
           tmpDir=$(hack/make-tmp-release-dir.sh OCIRepository)
-          flux push artifact --creds $creds --source https://23ke.cloud --revision $tag --path=$tmpDir oci://harbor.23t.dev/23ke-releases/23ke:$tag
+          flux push artifact --creds '$creds' --source https://23ke.cloud --revision $tag --path=$tmpDir oci://harbor.23t.dev/23ke-releases/23ke:$tag
       
       - name: Checkout 23ke-releases repo
         uses: actions/checkout@v3


### PR DESCRIPTION
deps are present in the runner's base image already
added single quotes to prevent variable expansion in harbor credentials

Signed-off-by: Jan Lohage <lohage@23technologies.cloud>