### PR TITLE
Don't let the user specify `.spec.dns.provider.domains`

### DIFF
--- a/docs/release-notes/v1.65.md
+++ b/docs/release-notes/v1.65.md
@@ -36,9 +36,6 @@ spec:
       secretRef:
         name: <dns-provider secret>
         namespace: <dns-provider secret-namespace>
-      domains:
-        include:
-          - <zone above seeds ingressDomain>
 ```
 
 You could use the dns-secret that is used by the internal seed (name: `base-dns-provider-secret`, namespace: `garden`) or provide a new one. Afterwards check, that the dnsrecord is created and that the new ingresscontroller is used for prometheus, grafana and terminal ingresses. If the new one is used, the old manually deployed ingress can be removed.


### PR DESCRIPTION
These fields are deprecated in v1.66

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>