### PR TITLE
Add k8s version requirements

### DIFF
--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -1,1 +1,15 @@
 # Release Notes next
+
+## Upstream Changes
+
+Please check the following sites for upstream release notes:
+
+- [Gardener releases](https://github.com/gardener/gardener/releases)
+- [Gardener-community charts releases](https://github.com/gardener-community/gardener-charts/releases)
+
+
+## 23KE Changes and Upgrade Path
+
+:::danger
+This version requires the base cluster's k8s version to lie in the range `>=1.24.0 < 1.26.0`. If, your base-cluster runs on a lower version of Kubernetes than `1.24.0`, you need to upgrade the basecluster before performing the 23KE update.
+:::

--- a/hack/ci/misc/shoot-template-hcloud-fsn1.yaml.tmpl
+++ b/hack/ci/misc/shoot-template-hcloud-fsn1.yaml.tmpl
@@ -47,7 +47,7 @@ spec:
   region: fsn1
   secretBindingName: hcloud-secret
   kubernetes:
-    version: 1.23.9
+    version: 1.24.3
     verticalPodAutoscaler:
       enabled: true
   purpose: evaluation

--- a/hack/ci/misc/shoot-template-hcloud-hel1.yaml.tmpl
+++ b/hack/ci/misc/shoot-template-hcloud-hel1.yaml.tmpl
@@ -47,7 +47,7 @@ spec:
   region: hel1
   secretBindingName: hcloud-secret
   kubernetes:
-    version: 1.23.9
+    version: 1.24.3
     verticalPodAutoscaler:
       enabled: true
   purpose: evaluation

--- a/pre-gardener/configuration/Chart.yaml
+++ b/pre-gardener/configuration/Chart.yaml
@@ -3,5 +3,5 @@ name: pre-gardener-configuration
 description: A Helm chart for the pre-gardener configuration files
 
 type: application
-
+kubeVersion: ">= 1.24.0 < 1.26.0"
 version: 0.0.1


### PR DESCRIPTION
The pre-gardener-configuration chart will only be installable on k8s
>= 1.24.0 < 1.26.0. Consequently, this version of 23KE requires the
base cluster's k8s version to lie in that range.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>