### PR TITLE
Create wildcard cert for internal seed explicitly

### DIFF
--- a/gardener/configuration/templates/seed-ingress-cert.yaml
+++ b/gardener/configuration/templates/seed-ingress-cert.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.issuer.enabled }}
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  annotations:
+    cert.gardener.cloud/class: base-cert-class
+  name: seed-ingress
+  namespace: garden
+spec:
+  commonName: "*.{{ include "gardenlet.ingressDomain" . }}"
+  issuerRef:
+    name: default-issuer
+    namespace: garden
+  secretRef:
+    name: seed-ingress-certificate
+    namespace: garden
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    gardener.cloud/role: controlplane-cert
+  name: seed-ingress-certificate
+  namespace: garden
+type: Opaque
+{{- end }}

--- a/pre-gardener/configuration/templates/ingress-nginx.yaml
+++ b/pre-gardener/configuration/templates/ingress-nginx.yaml
@@ -18,7 +18,6 @@ stringData:
         annotations:
 {{- if .Values.issuer.enabled }}
           cert.gardener.cloud/class: base-cert-class
-          cert.gardener.cloud/secretname: controlplane-cert-secret
 {{- end }}
       extraArgs:
         enable-ssl-passthrough: ""
@@ -29,15 +28,4 @@ stringData:
     defaultbackend:
       image:
         repository: {{ include "replaceRegistry" (dict "registry.k8s.io/defaultbackend-amd64" .Values.registryOverwrite) }}
-{{- end }}
-{{- if .Values.issuer.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    gardener.cloud/role: controlplane-cert
-  name: controlplane-cert-secret
-  namespace: garden
-type: Opaque
 {{- end }}


### PR DESCRIPTION
As we do not use dns annotations on our ingress-nginx anymore, we
cannot use the cert-controller-manager to create the internal seed
wildcard certificate anymore. Therefore, create it and the
corresponding secret explicitly.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>