### PR TITLE
Introduce NetworkPolicies

### DIFF
--- a/gardener/configuration/templates/gardener-base-values.yaml
+++ b/gardener/configuration/templates/gardener-base-values.yaml
@@ -18,11 +18,15 @@ stringData:
         replicaCount: 2
         vpa: true
         clusterIdentity: {{ .Values.clusterIdentity }}
+        podLabels:
+          networking.23ke.cloud/allow-all: allowed
 {{- if .Values.registryOverwrite }}
         image:
           repository: {{ include "replaceRegistry" (dict "eu.gcr.io/gardener-project/gardener/apiserver" .Values.registryOverwrite) }}
 {{- end }}
       admission:
+        podLabels:
+          networking.23ke.cloud/allow-all: allowed
         replicaCount: 2
         vpa: true
 {{- if .Values.registryOverwrite }}
@@ -30,6 +34,8 @@ stringData:
           repository: {{ include "replaceRegistry" (dict "eu.gcr.io/gardener-project/gardener/admission-controller" .Values.registryOverwrite) }}
 {{- end }}
       controller:
+        podLabels:
+          networking.23ke.cloud/allow-all: allowed
         replicaCount: 2
         vpa: true
 {{- if .Values.registryOverwrite }}
@@ -37,6 +43,8 @@ stringData:
           repository: {{ include "replaceRegistry" (dict "eu.gcr.io/gardener-project/gardener/controller-manager" .Values.registryOverwrite) }}
 {{- end }}
       scheduler:
+        podLabels:
+          networking.23ke.cloud/allow-all: allowed
         replicaCount: 2
         vpa: true
 {{- if .Values.registryOverwrite }}

--- a/gardener/configuration/templates/identity-base-values.yaml
+++ b/gardener/configuration/templates/identity-base-values.yaml
@@ -6,6 +6,8 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: |-
+    podLabels:
+      networking.23ke.cloud/allow-all: allowed
 {{- if .Values.registryOverwrite }}
     image:
       repository: {{ include "replaceRegistry" (dict "ghcr.io/dexidp/dex" .Values.registryOverwrite) }}

--- a/gardener/configuration/templates/kube-apiserver-gardenlet-base-values.yaml
+++ b/gardener/configuration/templates/kube-apiserver-gardenlet-base-values.yaml
@@ -10,6 +10,8 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: |-
+    podLabels:
+      networking.23ke.cloud/allow-all: allowed
     global:
       token:
         id: {{ $tokenId }}

--- a/gardener/configuration/templates/netpol-allow-all-garden-cert-management.yaml
+++ b/gardener/configuration/templates/netpol-allow-all-garden-cert-management.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-garden-cert-management
+  namespace: garden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: garden-cert-management
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/gardener/configuration/templates/netpol-allow-all-garden-etcd.yaml
+++ b/gardener/configuration/templates/netpol-allow-all-garden-etcd.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-garden-etcd
+  namespace: garden
+spec:
+  podSelector:
+    matchLabels:
+      component: etcd
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/gardener/configuration/templates/netpol-allow-all-garden-extensions.yaml
+++ b/gardener/configuration/templates/netpol-allow-all-garden-extensions.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-garden-extensions
+  namespace: garden
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - gardener-extension-admission-azure
+          - gardener-extension-admission-openstack
+          - gardener-extension-admission-hcloud
+          - gardener-extension-admission-gcp
+          - gardener-extension-admission-aws
+          - gardener-extension-admission-alicloud
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/gardener/configuration/templates/netpol-allow-all-garden-gardener-controlplane.yaml
+++ b/gardener/configuration/templates/netpol-allow-all-garden-gardener-controlplane.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-garden-gardener-controlplane
+  namespace: garden
+spec:
+  podSelector:
+    matchLabels:
+      networking.23ke.cloud/allow-all: allowed
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/gardener/configuration/templates/netpol-allow-all-garden-kube-apiserver.yaml
+++ b/gardener/configuration/templates/netpol-allow-all-garden-kube-apiserver.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-garden-kube-apiserver
+  namespace: garden
+spec:
+  podSelector:
+    matchLabels:
+      component: kube-apiserver
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pre-gardener/configuration/templates/ingress-nginx.yaml
+++ b/pre-gardener/configuration/templates/ingress-nginx.yaml
@@ -11,9 +11,14 @@ stringData:
       image:
         repository: {{ include "replaceRegistry" (dict "registry.k8s.io/ingress-nginx/controller" .Values.registryOverwrite) }}
 {{- end }}
+      admissionWebhooks:
+        patch:
+          labels:
+            networking.23ke.cloud/allow-all: allowed
       podLabels:
         app: nginx-ingress
         component: controller
+        networking.23ke.cloud/allow-all: allowed
       service:
         annotations:
 {{- if .Values.issuer.enabled }}


### PR DESCRIPTION
This is required to workaround Gardener networkpolicies which are
rolled out on seed clusters. For more information see here:
https://gardener.cloud/docs/gardener/usage/network_policies/

This is also seen as temporary fix. Once [this PR](https://github.com/fluxcd/kustomize-controller/pull/817) is merged, we can simply label all components rolled out by 23KE, and define a singe networkPolicy for this label.

In the long run, we should try to organize all components rolled out by 23KE in separate namespaces. This will require manual interaction when updating, however, it will make our deployment way cleaner.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>