### PR TITLE
Delete dnsentries before deleting the shoot

### DIFF
--- a/hack/ci/delete-shoot.sh
+++ b/hack/ci/delete-shoot.sh
@@ -10,6 +10,13 @@ rclone -q purge $REMOTE:$BACKUP_BUCKET || echo "Deleting backup bucket failed"
 # delete 23ke bucket
 mc rb -q --dangerous --force $MC_ALIAS/$BUCKET_23KE || echo "Deleting bucket failed"
 
+# delete ingresses and dnsentries, so that the dnsentries are not leaked on azure
+echo "Deleting dnsentries"
+kubectl delete -n garden ingress apiserver-ingress
+kubectl delete -n garden ingress gardener-dashboard-ingress
+kubectl delete -n garden ingress identity-ingress
+kubectl delete --all -n garden dnsentries.dns.gardener.cloud
+
 echo "Deleting shoot"
 export KUBECONFIG=hack/ci/secrets/gardener-kubeconfig.yaml
 kubectl annotate shoot "$SHOOT" confirmation.gardener.cloud/deletion=true --overwrite=true || echo "Annotating shoot failed"


### PR DESCRIPTION
This is expected to leak less dnsentries in the dns zone hosted on
azure

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>