### PR TITLE
Enable acme issuer by default

### DIFF
--- a/pre-gardener/configuration/values.yaml
+++ b/pre-gardener/configuration/values.yaml
@@ -10,5 +10,6 @@ domains:
     domain: "example.org"
 
 issuer:
+  enabled: true
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
In the simplest possible way for easy backports. I might spend a bit more time on the configuration charts and at least unify them.