### PR TITLE
Make renovate create non-existing files in postupgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,7 +113,7 @@
   "postUpgradeTasks": {
     "commands": [
       "cd hack/go/imagevector-importer && go run main.go import --config config.yaml > ../../../gardener/configuration/images.yaml",
-      "./hack/pull-helmchart.sh {{{depName}}} {{{newVersion}}} && git add helmcharts && git add docs/release-notes/next.md",
+      "./hack/pull-helmchart.sh {{{depName}}} {{{newVersion}}}",
     ],
     "fileFilters": ["gardener/configuration/images.yaml", "helmcharts/**/**", "docs/release-notes/next.md"],
     "executionMode": "update"


### PR DESCRIPTION
For me it seems that the issue is fixed in renovate v35. At least I can reproduce the rebase-bomb when running renoate v32 against my mwe repo (JensAc/renovate-mwe#8), and I can run renovate v35 as often as I want without any rebasing.

So, I updated our renovate instance to v35, and want to give this a try again, if you agree.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>