### PR TITLE
Add helm unittests to most charts

### DIFF
--- a/gardener/configuration/tests/cert-manager-ca_test.yaml
+++ b/gardener/configuration/tests/cert-manager-ca_test.yaml
@@ -1,0 +1,18 @@
+templates:
+  - cert-manager-ca.yaml
+tests:
+  - it: should create Issuer with default values
+    values:
+      - ../values-test.yaml
+    documentIndex: 2  # order in template is not actually important, but for this test to work it is
+    asserts:
+      - containsDocument:
+          apiVersion: cert-manager.io/v1
+          kind: Issuer
+          name: gardener-ca
+          namespace: flux-system
+      - equal:
+          path: spec
+          value:
+            ca:
+              secretName: gardener-ca-keypair

--- a/gardener/configuration/tests/dashboard_test.yaml
+++ b/gardener/configuration/tests/dashboard_test.yaml
@@ -1,0 +1,71 @@
+templates:
+  - dashboard-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            global:
+              virtualGarden:
+                enabled: true
+              dashboard:
+                apiServerUrl: https://api.mydomain.example.org/
+                sessionSecret: sessionSecret
+                ingress:
+                  hosts:
+                  - dashboard.mydomain.example.org
+                  annotations:
+                    kubernetes.io/ingress.class: nginx
+                    cert.gardener.cloud/purpose: managed
+                    cert.gardener.cloud/class: base-cert-class
+                    dns.gardener.cloud/dnsnames: "*"
+                    dns.gardener.cloud/ttl: "600"
+                    dns.gardener.cloud/class: base-dns-class
+                oidc:
+                  issuerUrl: https://identity.mydomain.example.org/oidc
+                  clientId: dashboard
+                  clientSecret: clientSecret
+                  redirectUri: https://dashboard.mydomain.example.org/auth/callback
+                  public:
+                    clientId: kube-kubectl
+                    usePKCE: true
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: "repository: myregistry.example.org/gardener-project/gardener/dashboard\n"
+  - it: should not set cert annotations if issuer is disabled
+    values:
+      - ../values-test.yaml
+    set:
+      issuer.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: stringData['values.yaml']
+          pattern: "cert.gardener.cloud/purpose: managed"
+      - notMatchRegex:
+          path: stringData['values.yaml']
+          pattern: "cert.gardener.cloud/class: base-cert-class"
+  - it: should contain ca at right indentation if issuer.ca is provided
+    values:
+      - ../values-test.yaml
+    set:
+      issuer.ca: |
+        myca has
+        multiple
+        lines
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: "myca has\\s{9}multiple\\s{9}lines"

--- a/gardener/configuration/tests/etcd-events_test.yaml
+++ b/gardener/configuration/tests/etcd-events_test.yaml
@@ -1,0 +1,26 @@
+templates:
+  - etcd-events-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: ""
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-
+            images:
+              etcd: myregistry.example.org/gardener-project/gardener/etcd:v.+
+              etcd-backup-restore: myregistry.example.org/gardener-project/gardener/etcdbrctl:v.+

--- a/gardener/configuration/tests/etcd_test.yaml
+++ b/gardener/configuration/tests/etcd_test.yaml
@@ -1,0 +1,28 @@
+templates:
+  - etcd-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: ""
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-
+            images:
+              etcd: myregistry.example.org/gardener-project/gardener/etcd:v.+
+              etcd-backup-restore: myregistry.example.org/gardener-project/gardener/etcdbrctl:v.+
+
+# TODO: missing backup.enabled: true and backup.provider cases

--- a/gardener/configuration/tests/extensions_test.yaml
+++ b/gardener/configuration/tests/extensions_test.yaml
@@ -1,0 +1,104 @@
+templates:
+  - extensions-base-values.yaml
+tests:
+  - it: should not enable admission for provider-hcloud
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |
+            provider-hcloud:
+              version: .+
+              admission:
+                enabled: false
+  - it: should enable admission for provider-aws
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |
+            provider-aws:
+              version: .+
+              admission:
+                enabled: true
+  - it: should enable admission for provider-gcp
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |
+            provider-gcp:
+              version: .+
+              admission:
+                enabled: true
+  - it: should enable admission for provider-openstack
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |
+            provider-openstack:
+              version: .+
+              admission:
+                enabled: true
+  - it: should enable admission for provider-azure
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |
+            provider-azure:
+              version: .+
+              admission:
+                enabled: true
+  - it: should set repository and imageVector with registryOverwrite, with provider-hcloud as an example
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        ghcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-
+            provider-hcloud:
+              version: .+
+              admission:
+                enabled: false
+                values:
+                  image:
+                    repository: myregistry.example.org/23technologies/gardener-extension-provider-hcloud/admission
+              values:
+                image:
+                  repository: myregistry.example.org/23technologies/gardener-extension-provider-hcloud
+                imageVectorOverwrite: \|
+                  images:
+                  [\s\S]*
+                  - name: machine-controller-manager-provider-hcloud
+                    repository: myregistry.example.org/23technologies/machine-controller-manager-provider-hcloud
+  - it: should deploy dnsControllerManager in shoot-dns-service
+    values:
+      - ../values-test.yaml
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-
+            shoot-dns-service:
+              version: .+
+              values:
+                dnsControllerManager:
+                  deploy: true
+                  image:
+                    repository: eu.gcr.io/gardener-project/dns-controller-manager
+                    tag: .+
+                  configuration:
+                    cacheTtl: 300
+                    controllers: dnscontrollers,dnssources
+                    dnsPoolResyncPeriod: 30m
+                    serverPortHttp: 8080

--- a/gardener/configuration/tests/garden-content_test.yaml
+++ b/gardener/configuration/tests/garden-content_test.yaml
@@ -1,0 +1,28 @@
+templates:
+  - garden-content-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            backups:
+              enabled: false
+  - it: should contain backup config with backup enabled/credentials
+    values:
+      - ../values-test.yaml
+    set:
+      backups.enabled: true
+      backups.credentials.foo: bar
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-
+            backups:
+              credentials:
+                foo: bar
+              enabled: true

--- a/gardener/configuration/tests/gardener_test.yaml
+++ b/gardener/configuration/tests/gardener_test.yaml
@@ -1,0 +1,58 @@
+templates:
+  - gardener-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            global:
+              deployment:
+                virtualGarden:
+                  enabled: true
+              defaultDomains:
+                - domain: mydomain.example.org
+                  provider: example
+                  credentials:
+                    token: example
+              internalDomain:
+                domain: internal.mydomain.example.org
+                provider: example
+                credentials:
+                  token: example
+              apiserver:
+                replicaCount: 2
+                vpa: true
+                clusterIdentity: garden-cluster-identity
+              admission:
+                replicaCount: 2
+                vpa: true
+              controller:
+                replicaCount: 2
+                vpa: true
+              scheduler:
+                replicaCount: 2
+                vpa: true
+
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+                  repository: myregistry.example.org/gardener-project/gardener/apiserver
+            [\s\S]*
+                  repository: myregistry.example.org/gardener-project/gardener/admission-controller
+            [\s\S]*
+                  repository: myregistry.example.org/gardener-project/gardener/controller-manager
+            [\s\S]*
+                  repository: myregistry.example.org/gardener-project/gardener/scheduler

--- a/gardener/configuration/tests/gardenlet_test.yaml
+++ b/gardener/configuration/tests/gardenlet_test.yaml
@@ -1,0 +1,87 @@
+templates:
+  - gardenlet-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            global:
+              token:
+                id: bootstrapTokenId
+                secret: bootstrapTokenSecret
+              additionalSecrets:
+                - name: base-dns-provider-secret
+                  namespace: garden
+                  data:
+                    token: example
+            config:
+              seedConfig:
+                spec:
+                  ingress:
+                    domain: internal.mydomain.example.org
+                    controller:
+                      kind: nginx
+                  dns:
+                    provider:
+                      type: example
+                      secretRef:
+                        name: base-dns-provider-secret
+                        namespace: garden
+              gardenClientConnection:
+                gardenClusterAddress: https://api.mydomain.example.org:443
+                bootstrapKubeconfig:
+                  secretRef:
+                    name: gardenlet-kubeconfig-bootstrap
+                    namespace: flux-system
+                kubeconfigSecret:
+                  name: gardenlet-kubeconfig
+                  namespace: garden
+  - it: should contain backup config with backup enabled/credentials
+    values:
+      - ../values-test.yaml
+    set:
+      backups:
+        enabled: true
+        provider: backuprovider
+        region: backupregion
+        credentials:
+          token: example
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+                  backup:
+                    provider: backuprovider
+                    region: backupregion
+                    secretRef:
+                      name: for-backups-internal-seed
+                      namespace: garden
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+            image:
+              repository: myregistry.example.org/gardener-project/gardener/gardenlet
+            imageVectorOverwrite: \|
+              images:[\s\S]*
+              - name: gardenlet
+                repository: myregistry.example.org/gardener-project/gardener/gardenlet[\s\S]*
+            componentImageVectorOverwrites: \|
+              components:
+              - name: etcd-druid
+                imageVectorOverwrite: \|
+                  images:[\s\S]*
+                  - name: etcd-backup-restore
+                    repository: myregistry.example.org/gardener-project/gardener/etcd

--- a/gardener/configuration/tests/identity_test.yaml
+++ b/gardener/configuration/tests/identity_test.yaml
@@ -1,0 +1,52 @@
+templates:
+  - identity-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            connectors: ~
+            issuerUrl: https://identity.mydomain.example.org/oidc
+            dashboardOrigins:
+              - 'https://dashboard.mydomain.example.org'
+            dashboardClientSecret: clientSecret
+            tls: ~
+            ingress:
+              annotations:
+                nginx.ingress.kubernetes.io/ssl-redirect: "true"
+                nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
+                kubernetes.io/ingress.class: nginx
+                cert.gardener.cloud/purpose: managed
+                cert.gardener.cloud/class: base-cert-class
+                dns.gardener.cloud/dnsnames: "*"
+                dns.gardener.cloud/ttl: "600"
+                dns.gardener.cloud/class: base-dns-class
+  - it: should not contain issuer annotations when issuer disabled
+    values:
+      - ../values-test.yaml
+    set:
+      issuer.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+                cert.gardener.cloud/purpose: managed
+                cert.gardener.cloud/class: base-cert-class
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        ghcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+            image:
+              repository: myregistry.example.org/dexidp/dex

--- a/gardener/configuration/tests/kube-apiserver_test.yaml
+++ b/gardener/configuration/tests/kube-apiserver_test.yaml
@@ -1,0 +1,72 @@
+templates:
+  - kube-apiserver-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            namespace: garden
+            serviceName: garden-kube-apiserver
+            replicas: 2
+            apiServer:
+              hostname: api.mydomain.example.org
+              serviceName: garden-kube-apiserver
+              oidcIssuerURL: https://identity.mydomain.example.org/oidc
+            ingress:
+              annotations:
+                dns.gardener.cloud/dnsnames: "*"
+                dns.gardener.cloud/ttl: "600"
+                dns.gardener.cloud/class: base-dns-class
+            etcd:
+              main:
+                endpoints: https://etcd:2379
+              events:
+                endpoints: https://etcd-events:2379
+              secretNames:
+                ca: etcd-ca
+                client: etcd-client
+            gardenletBootstrap:
+              createToken: true
+              token:
+                id: bootstrapTokenId
+                secret: bootstrapTokenSecret
+            tls:
+              kubeAPIServer:
+                staticTokens:
+                  healthCheck: healthCheck
+  - it: should contain ca at right indentation if issuer.ca is provided
+    values:
+      - ../values-test.yaml
+    set:
+      issuer.ca: |
+        myca has
+        multiple
+        lines
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+              identity:
+                ca: \|
+                  myca has
+                  multiple
+                  lines
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+      - ../images.yaml
+    set:
+      registryOverwrite:
+        registry.k8s.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+            images:
+              apiserver: myregistry.example.org/kube-apiserver:v.+
+              controllermanager: myregistry.example.org/kube-controller-manager:v.+

--- a/gardener/configuration/tests/seed-ingress-cert_test.yaml
+++ b/gardener/configuration/tests/seed-ingress-cert_test.yaml
@@ -1,0 +1,45 @@
+templates:
+  - seed-ingress-cert.yaml
+tests:
+  - it: should create Certificate with default values
+    values:
+      - ../values-test.yaml
+    documentIndex: 0  # order in template is not actually important, but for this test to work it is
+    asserts:
+      - containsDocument:
+          apiVersion: cert.gardener.cloud/v1alpha1
+          kind: Certificate
+          name: seed-ingress
+          namespace: garden
+      - equal:
+          path: metadata.annotations
+          value:
+            cert.gardener.cloud/class: base-cert-class
+      - equal:
+          path: spec
+          value:
+            commonName: "*.internal.mydomain.example.org"
+            issuerRef:
+              name: default-issuer
+              namespace: garden
+            secretRef:
+              name: seed-ingress-certificate
+              namespace: garden
+  - it: should create empty Secret with default values
+    values:
+      - ../values-test.yaml
+    documentIndex: 1  # order in template is not actually important, but for this test to work it is
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: seed-ingress-certificate
+          namespace: garden
+      - equal:
+          path: metadata.labels
+          value:
+            gardener.cloud/role: controlplane-cert
+      - notExists:
+          path: data
+      - notExists:
+          path: stringData

--- a/gardener/configuration/tests/webterminal_test.yaml
+++ b/gardener/configuration/tests/webterminal_test.yaml
@@ -1,0 +1,18 @@
+templates:
+  - webterminal-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            global:
+              runtime:
+                certificate:
+                  certManager:
+                    enabled: true
+                    issuerName: gardener-ca

--- a/gardener/configuration/values-test.yaml
+++ b/gardener/configuration/values-test.yaml
@@ -1,0 +1,18 @@
+dashboard:
+  sessionSecret: sessionSecret
+  clientSecret: clientSecret
+kubeAPIServer:
+  staticTokens:
+    healthCheck: healthCheck
+gardenlet:
+  bootstrapTokenId: bootstrapTokenId
+  bootstrapTokenSecret: bootstrapTokenSecret
+domains:
+  global:
+    domain: mydomain.example.org
+    provider: example
+    credentials:
+      token: example
+issuer:
+  acme:
+    email: mail@example.org

--- a/gardener/helmcharts/extensions-meta-chart/tests/certificate_test.yaml
+++ b/gardener/helmcharts/extensions-meta-chart/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+templates:
+  - certificate.yaml
+tests:
+  - it: should not create anything with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should create Certificates for os-exampleos and provider-example
+    set:
+      os-exampleos:
+        enabled: true
+        admission:
+          enabled: true
+      provider-example:
+        enabled: true
+        admission:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: cert-manager.io/v1
+          kind: Certificate
+          name: gardener-extension-os-exampleos-admission
+          namespace: flux-system
+        documentIndex: 0
+      - equal:
+          path: spec
+          value:
+            secretName: gardener-extension-os-exampleos-admission-tls
+            duration: 87600h #10y
+            usages:
+              - server auth
+            dnsNames:
+              - gardener-extension-admission-os-exampleos.garden
+              - gardener-extension-admission-os-exampleos.garden.svc
+            issuerRef:
+              name: gardener-ca
+        documentIndex: 0
+      - containsDocument:
+          apiVersion: cert-manager.io/v1
+          kind: Certificate
+          name: gardener-extension-example-admission
+          namespace: flux-system
+        documentIndex: 1
+      - equal:
+          path: spec
+          value:
+            secretName: gardener-extension-example-admission-tls
+            duration: 87600h #10y
+            usages:
+              - server auth
+            dnsNames:
+              - gardener-extension-admission-example.garden
+              - gardener-extension-admission-example.garden.svc
+            issuerRef:
+              name: gardener-ca
+        documentIndex: 1

--- a/gardener/helmcharts/extensions-meta-chart/tests/helmrelease-admission_test.yaml
+++ b/gardener/helmcharts/extensions-meta-chart/tests/helmrelease-admission_test.yaml
@@ -1,0 +1,42 @@
+templates:
+  - helmrelease-admission.yaml
+tests:
+  - it: should not create anything with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should create HelmRelease for os-exampleos and provider-example
+    set:
+      os-exampleos:
+        enabled: true
+        admission:
+          enabled: true
+      provider-example:
+        enabled: true
+        admission:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: admission-os-exampleos-application
+          namespace: flux-system
+        documentIndex: 0
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: admission-os-exampleos-runtime
+          namespace: flux-system
+        documentIndex: 1
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: admission-provider-example-application
+          namespace: flux-system
+        documentIndex: 2
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: admission-provider-example-runtime
+          namespace: flux-system
+        documentIndex: 3

--- a/gardener/helmcharts/extensions-meta-chart/tests/helmrelease-controller_test.yaml
+++ b/gardener/helmcharts/extensions-meta-chart/tests/helmrelease-controller_test.yaml
@@ -1,0 +1,30 @@
+templates:
+  - helmrelease-controller.yaml
+tests:
+  - it: should not create anything with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should create HelmRelease for os-exampleos and provider-example
+    set:
+      os-exampleos:
+        enabled: true
+        admission:
+          enabled: true
+      provider-example:
+        enabled: true
+        admission:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: os-exampleos
+          namespace: flux-system
+        documentIndex: 0
+      - containsDocument:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          name: provider-example
+          namespace: flux-system
+        documentIndex: 1

--- a/gardener/helmcharts/garden-content-chart/tests/secret-backup-internal-seed_test.yaml
+++ b/gardener/helmcharts/garden-content-chart/tests/secret-backup-internal-seed_test.yaml
@@ -1,0 +1,23 @@
+templates:
+  - secret-backup-internal-seed.yaml
+tests:
+  - it: should create secret when backups enabled
+    set:
+      backups.enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+  - it: should not create secret when backups disabled
+    set:
+      backups.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should contain credentials when backups enabled
+    set:
+      backups.enabled: true
+      backups.credentials.foo: bar
+    asserts:
+      - equal:
+          path: data.foo
+          value: bar

--- a/gardener/helmcharts/garden-content-chart/tests/secret-bootstrap-token_test.yaml
+++ b/gardener/helmcharts/garden-content-chart/tests/secret-bootstrap-token_test.yaml
@@ -1,0 +1,16 @@
+templates:
+  - secret-bootstrap-token.yaml
+tests:
+  - it: should create secret with default values
+    set:
+      backups.enabled: false
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData
+          value:
+            token-id: bootstrapTokenId
+            token-secret: bootstrapTokenSecret
+            usage-bootstrap-authentication: "true"
+            usage-bootstrap-signing: "true"

--- a/hack/run-helm-unittest.sh
+++ b/hack/run-helm-unittest.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+tmpDir=$(mktemp -d)
+
+helm unittest -q pre-gardener/configuration
+
+CONFIGVALUES="$(helm template --kube-version 1.24.0 pre-gardener/configuration --debug -f pre-gardener/configuration/values-test.yaml)"
+
+for chart in pre-gardener/addons pre-gardener/dnsprovider pre-gardener/issuer; do
+
+  CHARTNAME="$(basename $chart)"
+  export CHARTNAME
+
+  MYVALUES="$(echo "$CONFIGVALUES" | yq eval 'select(.metadata.name==strenv(CHARTNAME)+"-base-values") .stringData."values.yaml"' -)"
+
+  echo "$MYVALUES" > $tmpDir/$CHARTNAME-test-values.yaml
+
+  helm unittest -q $chart -v $tmpDir/$CHARTNAME-test-values.yaml
+
+done
+
+helm unittest -q gardener/configuration
+
+CONFIGVALUES="$(helm template --kube-version 1.24.0 gardener/configuration --debug -f gardener/configuration/values-test.yaml)"
+
+for chart in gardener/helmcharts/extensions-meta-chart gardener/helmcharts/garden-content-chart; do
+
+  CHARTNAME="$(basename $chart)"
+  export CHARTNAME
+
+  MYVALUES="$(echo "$CONFIGVALUES" | yq eval 'select(.metadata.name==strenv(CHARTNAME)+"-base-values") .stringData."values.yaml"' -)"
+
+  echo "$MYVALUES" > $tmpDir/$CHARTNAME-test-values.yaml
+
+  if [[ $CHARTNAME == "garden-content-chart" ]]; then
+    echo "$(echo "$CONFIGVALUES" | yq eval 'select(.metadata.name=="gardenlet-base-values") .stringData."values.yaml"' -)" >> $tmpDir/$CHARTNAME-test-values.yaml
+  fi
+
+  helm unittest -q $chart -v $tmpDir/$CHARTNAME-test-values.yaml
+
+done

--- a/pre-gardener/addons/tests/velero_test.yaml
+++ b/pre-gardener/addons/tests/velero_test.yaml
@@ -1,0 +1,13 @@
+templates:
+  - velero.yaml
+tests:
+  - it: should not create HelmRelease with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should create HelmRelease when backups are enabled
+    set:
+      backups.enabled: true
+    asserts:
+      - isKind:
+          of: HelmRelease

--- a/pre-gardener/addons/tests/vpa-v1-crd_test.yaml
+++ b/pre-gardener/addons/tests/vpa-v1-crd_test.yaml
@@ -1,0 +1,13 @@
+templates:
+  - vpa-v1-crd-gen.yaml
+tests:
+  - it: should not create CRD with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should create CRD when vpa-crd is enabled
+    set:
+      vpa.enabled: true
+    asserts:
+      - isKind:
+          of: CustomResourceDefinition

--- a/pre-gardener/configuration/tests/addons_test.yaml
+++ b/pre-gardener/configuration/tests/addons_test.yaml
@@ -1,0 +1,14 @@
+templates:
+  - addons-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            backups:
+              enabled: false

--- a/pre-gardener/configuration/tests/cert-management_test.yaml
+++ b/pre-gardener/configuration/tests/cert-management_test.yaml
@@ -1,0 +1,32 @@
+templates:
+  - cert-management-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            createCRDs:
+              issuers: false
+              certificates: false
+            configuration:
+              defaultIssuer: default-issuer
+              defaultIssuerDomainRanges: mydomain.example.org
+              certClass: base-cert-class
+              issuerNamespace: garden
+              dnsClass: base-dns-class
+              dnsNamespace: garden
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: "repository: myregistry.example.org/gardener-project/cert-controller-manager\n"

--- a/pre-gardener/configuration/tests/cert-manager_test.yaml
+++ b/pre-gardener/configuration/tests/cert-manager_test.yaml
@@ -1,0 +1,37 @@
+templates:
+  - cert-manager-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            installCRDs: true
+  - it: should create secret with test values and registryOverwrite
+    values:
+      - ../values-test.yaml
+    set:
+      registryOverwrite:
+        quay.io: myregistry.example.org
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            image:
+              repository: myregistry.example.org/jetstack/cert-manager-controller
+            cainjector:
+              image:
+                repository: myregistry.example.org/jetstack/cert-manager-cainjector
+            acmesolver:
+              image:
+                repository: myregistry.example.org/jetstack/cert-manager-acmesolver
+            startupapicheck:
+              image:
+                repository: myregistry.example.org/jetstack/cert-manager-ctl
+            installCRDs: true

--- a/pre-gardener/configuration/tests/dnsprovider_test.yaml
+++ b/pre-gardener/configuration/tests/dnsprovider_test.yaml
@@ -1,0 +1,18 @@
+templates:
+  - dnsprovider-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            domains:
+              - mydomain.example.org
+            provider: example
+            credentials:
+              token: example
+

--- a/pre-gardener/configuration/tests/external-dns-management_test.yaml
+++ b/pre-gardener/configuration/tests/external-dns-management_test.yaml
@@ -1,0 +1,27 @@
+templates:
+  - external-dns-management-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            external-dns-management:
+              enabled: true
+              configuration:
+                dnsClass: base-dns-class
+                identifier: garden-cluster-identity-base-dns
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+    set:
+      registryOverwrite:
+        eu.gcr.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: "repository: myregistry.example.org/gardener-project/dns-controller-manager\n"

--- a/pre-gardener/configuration/tests/ingress-nginx_test.yaml
+++ b/pre-gardener/configuration/tests/ingress-nginx_test.yaml
@@ -1,0 +1,54 @@
+templates:
+  - ingress-nginx.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |-
+            controller:
+              admissionWebhooks:
+                patch:
+                  labels:
+                    23ke.cloud/component: ingress-nginx
+              podLabels:
+                app: nginx-ingress
+                component: controller
+                23ke.cloud/component: ingress-nginx
+              service:
+                annotations:
+                  cert.gardener.cloud/class: base-cert-class
+              extraArgs:
+                enable-ssl-passthrough: ""
+  - it: should not contain issuer annotations when issuer disabled
+    values:
+      - ../values-test.yaml
+    set:
+      issuer.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: stringData['values.yaml']
+          pattern: "cert.gardener.cloud/class: base-cert-class"
+  - it: should set repository with registryOverwrite
+    values:
+      - ../values-test.yaml
+    set:
+      registryOverwrite:
+        registry.k8s.io: myregistry.example.org
+    asserts:
+      - matchRegex:
+          path: stringData['values.yaml']
+          pattern: |-2
+              image:
+                repository: myregistry.example.org/ingress-nginx/controller
+            [\s\S]*
+            patch:
+              image:
+                repository: myregistry.example.org/ingress-nginx/kube-webhook-certgen
+            defaultbackend:
+              image:
+                repository: myregistry.example.org/defaultbackend-amd64

--- a/pre-gardener/configuration/tests/issuer_test.yaml
+++ b/pre-gardener/configuration/tests/issuer_test.yaml
@@ -1,0 +1,14 @@
+templates:
+  - issuer-base-values.yaml
+tests:
+  - it: should create secret with test values
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |
+            email: mail@example.org
+            server: https://acme-v02.api.letsencrypt.org/directory

--- a/pre-gardener/configuration/tests/velero_test.yaml
+++ b/pre-gardener/configuration/tests/velero_test.yaml
@@ -1,0 +1,50 @@
+templates:
+  - velero-base-values.yaml
+tests:
+  - it: should create secret without content
+    values:
+      - ../values-test.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData
+          value:
+            values.yaml: ""
+  - it: should create secret when backup enabled
+    values:
+      - ../values-test.yaml
+    set:
+      backups:
+        enabled: true
+        credentials:
+          foo: bar
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData['values.yaml']
+          value: |
+            snapshotsEnabled: false
+
+            schedules:
+                full-cluster-hourly:
+                  labels:
+                    backup: full-cluster
+                    schedule: hourly
+                  schedule: "@every 1h"
+                  template:
+                    ttl: "52h0m"
+                    includedNamespaces:
+                      - '*'
+                full-cluster-daily:
+                  labels:
+                    backup: full-cluster
+                    schedule: daily
+                  schedule: "@every 24h"
+                  template:
+                    ttl: "2160h0m"
+                    includedNamespaces:
+                      - '*'
+
+## TODO: check for backup provider variations and their credentials

--- a/pre-gardener/configuration/values-test.yaml
+++ b/pre-gardener/configuration/values-test.yaml
@@ -1,0 +1,9 @@
+domains:
+  global:
+    domain: mydomain.example.org
+    provider: example
+    credentials:
+      token: example
+issuer:
+  acme:
+    email: mail@example.org

--- a/pre-gardener/dnsprovider/tests/dnsprovider_test.yaml
+++ b/pre-gardener/dnsprovider/tests/dnsprovider_test.yaml
@@ -1,0 +1,25 @@
+templates:
+  - dnsprovider.yaml
+tests:
+  - it: should create DNSProvider with default values
+    asserts:
+      - containsDocument:
+          apiVersion: dns.gardener.cloud/v1alpha1
+          kind: DNSProvider
+          name: base-dns-provider
+          namespace: garden
+      - equal:
+          path: metadata.annotations
+          value:
+            dns.gardener.cloud/class: base-dns-class
+      - equal:
+          path: spec
+          value:
+            domains:
+              include:
+                - mydomain.example.org
+            secretRef:
+              name: base-dns-provider-secret
+              namespace: garden
+            type: example
+

--- a/pre-gardener/dnsprovider/tests/secret_test.yaml
+++ b/pre-gardener/dnsprovider/tests/secret_test.yaml
@@ -1,0 +1,15 @@
+templates:
+  - secret.yaml
+tests:
+  - it: should create secret with default values
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: base-dns-provider-secret
+          namespace: garden
+      - equal:
+          path: data
+          value:
+            token: example
+

--- a/pre-gardener/issuer/tests/issuer_test.yaml
+++ b/pre-gardener/issuer/tests/issuer_test.yaml
@@ -1,0 +1,21 @@
+templates:
+  - issuer.yaml
+tests:
+  - it: should create Issuer with default values
+    asserts:
+      - containsDocument:
+          apiVersion: cert.gardener.cloud/v1alpha1
+          kind: Issuer
+          name: default-issuer
+          namespace: garden
+      - equal:
+          path: metadata.annotations
+          value:
+            cert.gardener.cloud/class: base-cert-class
+      - equal:
+          path: spec
+          value:
+            acme:
+              autoRegistration: true
+              email: mail@example.org
+              server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
I think this covers a large enough part of our own charts to be helpful in judging future changes. We can add tests whenever behavior of the templates is changed.

I don't want to figure out how to run this via an action or pre-commit or enforce it somehow _right now_ so here is the output of ./hack/run-helm-unittest.sh

```
### Chart [ pre-gardener-configuration ] pre-gardener/configuration

 PASS  	pre-gardener/configuration/tests/addons_test.yaml
 PASS  	pre-gardener/configuration/tests/cert-management_test.yaml
 PASS  	pre-gardener/configuration/tests/cert-manager_test.yaml
 PASS  	pre-gardener/configuration/tests/dnsprovider_test.yaml
 PASS  	pre-gardener/configuration/tests/external-dns-management_test.yaml
 PASS  	pre-gardener/configuration/tests/ingress-nginx_test.yaml
 PASS  	pre-gardener/configuration/tests/issuer_test.yaml
 PASS  	pre-gardener/configuration/tests/velero_test.yaml

Charts:      1 passed, 1 total
Test Suites: 8 passed, 8 total
Tests:       14 passed, 14 total
Snapshot:    0 passed, 0 total
Time:        17.350708ms


### Chart [ extensions ] pre-gardener/addons

 PASS  	pre-gardener/addons/tests/velero_test.yaml
 PASS  	pre-gardener/addons/tests/vpa-v1-crd_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshot:    0 passed, 0 total
Time:        3.167625ms


### Chart [ dnsprovider ] pre-gardener/dnsprovider

 PASS  	pre-gardener/dnsprovider/tests/dnsprovider_test.yaml
 PASS  	pre-gardener/dnsprovider/tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshot:    0 passed, 0 total
Time:        2.210167ms


### Chart [ issuer ] pre-gardener/issuer

 PASS  	pre-gardener/issuer/tests/issuer_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        1.473167ms


### Chart [ extensions ] gardener/configuration

 PASS  	gardener/configuration/tests/cert-manager-ca_test.yaml
 PASS  	gardener/configuration/tests/dashboard_test.yaml
 PASS  	gardener/configuration/tests/etcd-events_test.yaml
 PASS  	gardener/configuration/tests/etcd_test.yaml
 PASS  	gardener/configuration/tests/extensions_test.yaml
 PASS  	gardener/configuration/tests/garden-content_test.yaml
 PASS  	gardener/configuration/tests/gardener_test.yaml
 PASS  	gardener/configuration/tests/gardenlet_test.yaml
 PASS  	gardener/configuration/tests/identity_test.yaml
 PASS  	gardener/configuration/tests/kube-apiserver_test.yaml
 PASS  	gardener/configuration/tests/seed-ingress-cert_test.yaml
 PASS  	gardener/configuration/tests/webterminal_test.yaml

Charts:      1 passed, 1 total
Test Suites: 12 passed, 12 total
Tests:       32 passed, 32 total
Snapshot:    0 passed, 0 total
Time:        263.861291ms


### Chart [ extensions ] gardener/helmcharts/extensions-meta-chart

 PASS  	gardener/helmcharts/extensions-meta-chart/tests/certificate_test.yaml
 PASS  	gardener/helmcharts/extensions-meta-chart/tests/helmrelease-admission_test.yaml
 PASS  	gardener/helmcharts/extensions-meta-chart/tests/helmrelease-controller_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       6 passed, 6 total
Snapshot:    0 passed, 0 total
Time:        6.546ms


### Chart [ garden-content ] gardener/helmcharts/garden-content-chart

 PASS  	gardener/helmcharts/garden-content-chart/tests/secret-backup-internal-seed_test.yaml
 PASS  	gardener/helmcharts/garden-content-chart/tests/secret-bootstrap-token_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshot:    0 passed, 0 total
Time:        3.326916ms

```