### PR TITLE
renovate: fix extensions yaml path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,7 +94,7 @@
   "regexManagers": [
     {
       "fileMatch": [
-        "^configuration/configuration/templates/extensions-base-values.yaml$"
+        "^configuration/configuration/templates/extensions.yaml$"
       ],
       "datasourceTemplate": "helm",
       "registryUrlTemplate": "https://gardener-community.github.io/gardener-charts",


### PR DESCRIPTION
extensions-base-values.yaml was renamed to extensions.yaml in #797