### PR TITLE
Download 23kectl release version via install.sh

### DIFF
--- a/hack/ci/04-23ke.sh
+++ b/hack/ci/04-23ke.sh
@@ -22,18 +22,18 @@ if [ -d "hack/go/23kectl" ]; then
 		go build .
 		cp 23kectl $repoRoot
     cd $repoRoot
+    _23KECTL=$repoRoot/23kectl
 else
-		wget -q -O 23kectl https://github.com/23technologies/23kectl/releases/download/${_23KECTL_VERSION}/23kectl-${_23KECTL_VERSION}-linux-amd64
-		chmod +x 23kectl
+    _23KECTL="$(install_23kectl $_23KECTL_VERSION)"
 fi
 
-./23kectl install --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml --config hack/ci/misc/23kectl-config.yaml
+$_23KECTL install --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml --config hack/ci/misc/23kectl-config.yaml
 
 echo "Waiting for Kustomization gardener"
-$KUBECTL wait kustomization gardener -n flux-system --for=condition=ready --timeout=10m  || { ./23kectl doctor --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml; exit 1; }
+$KUBECTL wait kustomization gardener -n flux-system --for=condition=ready --timeout=10m  || { $_23KECTL doctor --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml; exit 1; }
 
 echo "Waiting for all Helmreleases to be ready"
-$KUBECTL wait helmrelease -A --all --for=condition=ready --timeout=10m || { ./23kectl doctor --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml; exit 1; }
+$KUBECTL wait helmrelease -A --all --for=condition=ready --timeout=10m || { $_23KECTL doctor --kubeconfig hack/ci/secrets/shoot-kubeconfig.yaml; exit 1; }
 
 echo "Get the kubeconfig for the virtual garden"
 $KUBECTL get secrets -n garden garden-kubeconfig-for-admin -o go-template='{{.data.kubeconfig | base64decode }}' > hack/ci/secrets/apiserver-in-shoot-kubeconfig.yaml

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -100,7 +100,6 @@ install_helm() {
   fi
 }
 
-
 install_rclone() {
   # renovate: datasource=github-tags depName=rclone/rclone
   VERSION=v1.62.2
@@ -116,4 +115,19 @@ install_rclone() {
 
     _setVersion $RCLONE $VERSION
   fi
+}
+
+install_23kectl() {
+  # not under renovate control
+  VERSION=$1
+  local _23KECTL="$TOOLS_BIN_DIR/23kectl"
+
+  if _isStale $_23KECTL $VERSION; then
+		curl -L -o $_23KECTL https://github.com/23technologies/23kectl/releases/download/${_23KECTL_VERSION}/23kectl-${_23KECTL_VERSION}-${TOOLS_KERNEL}-${TOOLS_ARCH}
+		chmod +x $_23KECTL
+
+    _setVersion $_23KECTL $VERSION
+  fi
+
+  echo $_23KECTL
 }


### PR DESCRIPTION
The foremost goal was to fix the hardcoded linux/amd64 for 23kectl and not re-download the release version on every run (unless version has changed). So the idea was to just make it the same as the other tools...

The function turned out a bit different tough, install_23kectl accepts the version as an argument, and then "returns" the path to the binary and we then only set and use it in 04-23ke.sh, as there is this additional logic of having hack/go/23kectl or not. Moving the version definition and the `if [ -d "hack/go/23kectl" ]` to install.sh did not feel quite right either, but I'm happy for feedback.