### PR TITLE
renovate: move imagevector import command to script

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,7 +123,7 @@
   "addLabels": ["version-bump"],
   "postUpgradeTasks": {
     "commands": [
-      "cd hack/go/imagevector-importer && go run main.go import --config config.yaml > ../../../configuration/configuration/images.yaml",
+      "./hack/import-imagevectors.sh",
       "./hack/pull-helmchart.sh {{{depName}}} {{{newVersion}}}",
     ],
     "fileFilters": ["configuration/configuration/images.yaml", "helmcharts/**/**", "docs/release-notes/next.md"],

--- a/hack/import-imagevectors.sh
+++ b/hack/import-imagevectors.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cd hack/go/imagevector-importer
+go run main.go import --config config.yaml > ../../../configuration/configuration/images.yaml


### PR DESCRIPTION
As of #797 images.yaml has moved. To keep this working for existing release branches the import command needs to be part of the respective branch.