### PR TITLE
Add kube-apiserver ingress rule for terminal-manger

### DIFF
--- a/gardener/networkpolicies/garden-kube-apiserver.yaml
+++ b/gardener/networkpolicies/garden-kube-apiserver.yaml
@@ -63,6 +63,12 @@ spec:
         podSelector:
           matchLabels:
             app: kustomize-controller
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: flux-system
+        podSelector:
+          matchLabels:
+            component: terminal-manager
   egress:
     - {}
   policyTypes:


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>