### PR TITLE
Download kubectl from 23t nextcloud

### DIFF
--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -57,7 +57,8 @@ install_kubectl() {
   VERSION=v0.27.3
 
   if _isStale $KUBECTL $VERSION; then
-    curl -Lo $KUBECTL "https://dl.k8s.io/release/${VERSION/v0/v1}/bin/$TOOLS_KERNEL/$TOOLS_ARCH/kubectl"
+    # curl -Lo $KUBECTL "https://dl.k8s.io/release/${VERSION/v0/v1}/bin/$TOOLS_KERNEL/$TOOLS_ARCH/kubectl"
+    curl -Lo $KUBECTL "https://nextcloud.23technologies.cloud/s/KHg4G4F2D36fLoT?path=/${VERSION/v0/v1}/bin/$TOOLS_KERNEL/$TOOLS_ARCH/kubectl"
     chmod +x $KUBECTL
 
     _setVersion $KUBECTL $VERSION


### PR DESCRIPTION
k8s.io download servers seem to block hetzner IPs. This is a temporary workaround.