### PR TITLE
Add secrets from gardener-controlplane chart to garden-content chart

### DIFF
--- a/gardener/garden-content.yaml
+++ b/gardener/garden-content.yaml
@@ -24,6 +24,7 @@ spec:
         name: 23ke
         namespace: flux-system
       interval: 1m
+      reconcileStrategy: Revision
   valuesFrom:
     - kind: Secret
       name: garden-content-base-values
@@ -31,3 +32,13 @@ spec:
     - kind: Secret
       name: gardenlet-base-values
       optional: false
+      # also feed in the gardener-values as several secrets were removed from the gardener-controlplane chart,
+      # (https://github.com/gardener/gardener/pull/8308) but are still required in 23ke as we use the basecluster
+      # as initial seed cluster
+    - kind: Secret
+      name: gardener-base-values
+      optional: false
+    - kind: Secret
+      name: gardener-values
+      optional: false
+

--- a/gardener/garden-content/templates/secret-alerting.yaml
+++ b/gardener/garden-content/templates/secret-alerting.yaml
@@ -1,0 +1,44 @@
+# imported from https://github.com/23technologies/23ke/tree/release-v1.76/helmcharts/gardener-controlplane/charts/application/templates
+{{- define "gardener.secret-alerting" -}}
+{{- range $key, $config := .Values.global.alerting }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alerting-{{ $key }}
+  namespace: garden
+  labels:
+    app: gardener
+    chart: "{{ $.Chart.Name }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+    gardener.cloud/role: alerting
+type: Opaque
+data:
+  auth_type: {{ ( required ".alerting[].auth_type is required" $config.auth_type ) | b64enc }}
+{{- if eq $config.auth_type "smtp" }}
+  to: {{ ( required ".alerting[].to is required" $config.to ) | b64enc }}
+  from: {{ ( required ".alerting[].from is required" $config.from ) | b64enc }}
+  smarthost: {{ ( required ".alerting[].smarthost is required" $config.smarthost ) | b64enc }}
+  auth_username: {{ ( required ".alerting[].auth_username is required" $config.auth_username ) | b64enc }}
+  auth_identity: {{ ( required ".alerting[].auth_identity is required" $config.auth_identity ) | b64enc }}
+  auth_password: {{ ( required ".alerting[].auth_password is required" $config.auth_password ) | b64enc }}
+{{- end }}
+{{- if eq $config.auth_type "none" }}
+  url: {{ ( required ".alerting[].url is required" $config.url ) | b64enc }}
+{{- end }}
+{{- if eq $config.auth_type "basic" }}
+  url: {{ ( required ".alerting[].url is required" $config.url ) | b64enc }}
+  username: {{ ( required ".alerting[].username is required" $config.username ) | b64enc }}
+  password: {{ ( required ".alerting[].password is required" $config.password ) | b64enc }}
+{{- end }}
+{{- if eq $config.auth_type "certificate" }}
+  url: {{ ( required ".alerting[].url is required" $config.url ) | b64enc }}
+  ca.crt: {{ ( required ".alerting[].ca_crt is required" $config.ca_crt ) | b64enc }}
+  tls.crt: {{ ( required ".alerting[].tls_crt is required" $config.tls_cert ) | b64enc }}
+  tls.key: {{ ( required ".alerting[].tls_key is required" $config.tls_key ) | b64enc }}
+  insecure_skip_verify: {{ ( required ".alerting[].insecure_skip_verify is required" $config.insecure_skip_verify ) | b64enc }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- include "gardener.secret-alerting" . }}

--- a/gardener/garden-content/templates/secret-default-domain.yaml
+++ b/gardener/garden-content/templates/secret-default-domain.yaml
@@ -1,0 +1,27 @@
+# imported from https://github.com/23technologies/23ke/tree/release-v1.76/helmcharts/gardener-controlplane/charts/application/templates
+{{- define "gardener.secret-default-domain" -}}
+{{- range $key, $domain := .Values.global.defaultDomains }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-domain-{{ ( required ".defaultDomains[].domain is required" (replace "." "-" $domain.domain) ) }}
+  namespace: garden
+  labels:
+    app: gardener
+    chart: "{{ $.Chart.Name }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+    gardener.cloud/role: default-domain
+  annotations:
+    dns.gardener.cloud/provider: {{ ( required ".defaultDomains[].provider is required" $domain.provider ) }}
+    dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
+    {{- if $domain.zone }}
+    dns.gardener.cloud/zone: {{ $domain.zone }}
+    {{- end }}
+type: Opaque
+data:
+{{ toYaml $domain.credentials | indent 2 }}
+{{- end }}
+{{- end -}}
+{{- include "gardener.secret-default-domain" . }}

--- a/gardener/garden-content/templates/secret-internal-domain.yaml
+++ b/gardener/garden-content/templates/secret-internal-domain.yaml
@@ -1,0 +1,25 @@
+# imported from https://github.com/23technologies/23ke/tree/release-v1.76/helmcharts/gardener-controlplane/charts/application/templates
+{{- define "gardener.secret-internal-domain" -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: internal-domain-{{ ( required ".internalDomain.domain is required" (replace "." "-" .Values.global.internalDomain.domain) ) }}
+  namespace: garden
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    gardener.cloud/role: internal-domain
+  annotations:
+    dns.gardener.cloud/provider: {{ ( required ".internalDomain.provider is required" .Values.global.internalDomain.provider ) }}
+    dns.gardener.cloud/domain: {{ ( required ".internalDomain.domain is required" .Values.global.internalDomain.domain ) }}
+    {{- if .Values.global.internalDomain.zone }}
+    dns.gardener.cloud/zone: {{ .Values.global.internalDomain.zone }}
+    {{- end }}
+type: Opaque
+data:
+{{ toYaml .Values.global.internalDomain.credentials | indent 2 }}
+{{- end -}}
+{{- include "gardener.secret-internal-domain" . }}

--- a/gardener/garden-content/templates/secret-openvpn-diffie-hellman.yaml
+++ b/gardener/garden-content/templates/secret-openvpn-diffie-hellman.yaml
@@ -1,0 +1,20 @@
+# imported from https://github.com/23technologies/23ke/tree/release-v1.76/helmcharts/gardener-controlplane/charts/application/templates
+{{- define "gardener.secret-openvpn-diffie-hellman" -}}
+{{- if .Values.global.openVPNDiffieHellmanKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openvpn-diffie-hellman-key
+  namespace: garden
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    gardener.cloud/role: openvpn-diffie-hellman
+type: Opaque
+data:
+  dh2048.pem: {{ .Values.global.openVPNDiffieHellmanKey | b64enc }}
+{{- end }}
+{{- end -}}
+{{- include "gardener.secret-openvpn-diffie-hellman" . }}


### PR DESCRIPTION
[the gardener-controlplane chart used to create these before 1.77.0](https://github.com/gardener/gardener/pull/8308)