### PR TITLE
Add "virtual-garden-kube-apiserver" to certificate

### DIFF
--- a/gardener/certificates/templates/cert-manager-ca.yaml
+++ b/gardener/certificates/templates/cert-manager-ca.yaml
@@ -95,6 +95,9 @@ spec:
     - garden-kube-apiserver
     - garden-kube-apiserver.garden
     - garden-kube-apiserver.garden.svc
+    - virtual-garden-kube-apiserver
+    - virtual-garden-kube-apiserver.garden
+    - virtual-garden-kube-apiserver.garden.svc
     - {{ .Values.gardener }}
   issuerRef:
     name: gardener-ca


### PR DESCRIPTION
which aligns with how gardener operator names this service, and how gardener netpols are named