### PR TITLE
Temporarily fix upstream issue with velero-upgrade-crds pod's memory limits

### DIFF
--- a/configuration/configuration/templates/velero.yaml
+++ b/configuration/configuration/templates/velero.yaml
@@ -112,4 +112,13 @@ stringData:
             ttl: "2160h0m"
             includedNamespaces:
               - '*'
+
+    # TODO: Remove upgradeJobResources once https://github.com/vmware-tanzu/helm-charts/issues/515 is resolved
+    upgradeJobResources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        cpu: 100m
+        memory: 512Mi
 {{- end }}


### PR DESCRIPTION
.upgradeJobResources defaults are too low (128Mi limit). set them to something generous that actually works. 

Revert this once https://github.com/vmware-tanzu/helm-charts/issues/515 is resolved