### PR TITLE
Yake local on Mac

### DIFF
--- a/hack/ci/yake-local/config/addons-values.yaml
+++ b/hack/ci/yake-local/config/addons-values.yaml
@@ -6,7 +6,5 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: |
-    backups:
-      enabled: false
     vpa:
       enabled: true

--- a/hack/ci/yake-local/config/gardener-values.yaml
+++ b/hack/ci/yake-local/config/gardener-values.yaml
@@ -9,7 +9,7 @@ stringData:
     global:
       deployment:
         virtualGarden:
-          clusterIP: 10.96.0.100
+          clusterIP: 10.2.0.42
       scheduler:
         config:
           schedulers:

--- a/hack/ci/yake-local/config/gardenlet-values.yaml
+++ b/hack/ci/yake-local/config/gardenlet-values.yaml
@@ -15,12 +15,12 @@ stringData:
             provider:
               type: local
           networks:
-            nodes: ${NODE_CIDR}
-            pods: 10.244.0.0/16
-            services: 10.96.0.0/13
+            nodes: 172.18.0.0/16
+            pods: 10.1.0.0/16
+            services: 10.2.0.0/16
             shootDefaults:
-              pods: 100.100.0.0/16
-              services: 100.101.0.0/16
+              pods: 10.3.0.0/16
+              services: 10.4.0.0/16
           provider:
             region: local
             type: local

--- a/hack/ci/yake-local/kind-config.yaml
+++ b/hack/ci/yake-local/kind-config.yaml
@@ -5,3 +5,7 @@ nodes:
   - role: worker
   - role: worker
   - role: worker
+networking:
+  ipFamily: ipv4
+  podSubnet: 10.1.0.0/16
+  serviceSubnet: 10.2.0.0/16

--- a/hack/ci/yake-local/m1-mac-etcd-values.yaml
+++ b/hack/ci/yake-local/m1-mac-etcd-values.yaml
@@ -1,0 +1,22 @@
+# this avoids running the arm64 etcd 3.4 image, which needs a special env var to work on m1 macs
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-values
+  namespace: flux-system
+type: Opaque
+stringData:
+  values.yaml: |
+    images:
+      etcd: eu.gcr.io/gardener-project/gardener/etcd:latest-linux-amd64
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-events-values
+  namespace: flux-system
+type: Opaque
+stringData:
+  values.yaml: |
+    images:
+      etcd: eu.gcr.io/gardener-project/gardener/etcd:latest-linux-amd64

--- a/hack/ci/yake-local/work.sh
+++ b/hack/ci/yake-local/work.sh
@@ -126,6 +126,11 @@ _create_flux () {
     $ENVSUBST "\$NODE_CIDR" < "$file" | $KUBECTL apply -f -
   done
 
+  ## M1 Mac workaround
+  if [[ "$(uname -s)-$(uname -m)" == "Darwin-arm64" ]]; then
+    $KUBECTL apply -f m1-mac-etcd-values.yaml
+  fi
+
   cat <<EOF | $KUBECTL apply -f -
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/hack/ci/yake-local/work.sh
+++ b/hack/ci/yake-local/work.sh
@@ -12,7 +12,8 @@ CLUSTERNAME="yake-local"
 VGARDEN_KUBECONFIG="/tmp/$CLUSTERNAME-apiserver.yaml"
 
 _create_cluster () {
-  $KIND create cluster --config kind-config.yaml --name $CLUSTERNAME --image=kindest/node:v1.26.6
+  # If export kubeconfig fails, the cluster does not yet exist and we need to create it
+  $KIND export kubeconfig -n $CLUSTERNAME > /dev/null 2>&1  || $KIND create cluster --config kind-config.yaml --name $CLUSTERNAME --image=kindest/node:v1.26.6
 	$KIND export kubeconfig -n $CLUSTERNAME
 	$KUBECTL config set-context --current --namespace=default
 }
@@ -196,10 +197,9 @@ _ensure_hosts() {
     printf .
     sleep 3
   done
-  echo " ok"
 
   $KUBECTL wait --for=condition=ready -n flux-system hr gardener-runtime --timeout=10m
-
+  echo " ok"
 
   garden_ingress_ip=$($KUBECTL get svc -n garden garden-ingress-nginx-controller -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
 

--- a/hack/ci/yake-local/work.sh
+++ b/hack/ci/yake-local/work.sh
@@ -53,7 +53,6 @@ _create_loadbalancer () {
   $KUBECTL apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
   $KUBECTL wait --namespace metallb-system --for=condition=ready pod --all --timeout=90s
 
-  lbrange=$(docker network inspect kind | $YQ '.[0].IPAM.Config[0].Subnet' | $SIPCALC -s24 - | head -n 10 | tail -n 1 | awk '{print $3"-"$5}')
   cat <<EOF | $KUBECTL apply -f -
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -62,7 +61,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - "$lbrange"
+  - "172.18.0.23-172.18.0.42"
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -121,7 +120,7 @@ _create_flux () {
   $KUBECTL apply -f ../../../flux-system/gotk-components.yaml
 
   ############# yake config #################
-  export NODE_CIDR=$(docker network inspect kind | $YQ '.[0].IPAM.Config[0].Subnet' -r)
+  export NODE_CIDR="172.18.0.0/16"
   for file in config/*; do
     $ENVSUBST "\$NODE_CIDR" < "$file" | $KUBECTL apply -f -
   done

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -157,7 +157,7 @@ install_envsubst() {
 		# not under renovate control
 		VERSION=v1.2.0
 
-		if _isStale "$SIPCALC" "$VERSION"; then
+		if _isStale "$ENVSUBST" "$VERSION"; then
 				curl -L https://github.com/a8m/envsubst/releases/download/${VERSION}/envsubst-`uname -s`-`uname -m` -o $ENVSUBST
 				chmod +x $ENVSUBST
 


### PR DESCRIPTION
Setup kind docker network just as gardeners kind-up.sh with static network ranges. Also explicitly use pod/service network static ranges.

M1 Mac workaround: etcd 3.4 has an arm64 image, but arm64 isn't actually supported until 3.5. Workaround is to use an amd64 image variant.