### PR TITLE
Downgrade ingress-nginx to 4.8.3 as 4.8.4 was a broken release that got removed

### DIFF
--- a/pre-gardener/ingress-nginx.yaml
+++ b/pre-gardener/ingress-nginx.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.8.4
+      version: 4.8.3
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx


### PR DESCRIPTION
https://github.com/kubernetes/ingress-nginx/issues/10784