### PR TITLE
Switch to github runners where possible

### DIFF
--- a/.github/workflows/build-and-push-provider-local.yaml
+++ b/.github/workflows/build-and-push-provider-local.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   buildAndPush:
     name: Build and push extension-provider-local to ghcr
-    runs-on: self-hosted
+    runs-on: ubuntu-22
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: self-hosted
+    runs-on: ubuntu-22
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   prepare:
-    runs-on: self-hosted
+    runs-on: ubuntu-22
     name: Prepare
     env:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/yaml-syntax-check.yml
+++ b/.github/workflows/yaml-syntax-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-yaml-syntax:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Since we're public now and github's runners are pwoerful enough, there's no point in using self-hosted runners.