### PR TITLE
Fix automatic patch releases on release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,9 +43,11 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - name: Configure version to release
         id: version
+        env:
+          COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
         run: |
           if [[ -z "$version" ]]; then
-            version=$(echo ${{ github.event.head_commit.message }} | grep -oP "Update gardener-controlplane to v\K([0-9]{1,}[.][0-9]{1,}[.][0-9]{1,})")-0
+            version=$(echo "$COMMIT_MESSAGE" | grep -oP "Update gardener-controlplane to v\K([0-9]{1,}[.][0-9]{1,}[.][0-9]{1,})")-0
           fi
           echo "version=$version" | tee $GITHUB_ENV | tee $GITHUB_OUTPUT
       - name: Prepare release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,5 +56,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: /tmp/release-body.md
-          tag_name: v${{ github.event.inputs.version }}
+          tag_name: v${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
Patch releases now work correctly when triggered by a push on `release-v*` branches
Parsing the version now doesn't break for multiline commit messages.
The github release now uses the parsed version number.