### PR TITLE
Force-enable automountServiceAccountToken in extension admission controller helm releases

### DIFF
--- a/gardener/extensions/templates/helmrelease-admission.yaml
+++ b/gardener/extensions/templates/helmrelease-admission.yaml
@@ -65,6 +65,16 @@ spec:
     remediation:
       retries: 3
     createNamespace: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |
+              - op: replace
+                path: /spec/template/spec/automountServiceAccountToken
+                value: true
+            target:
+              kind: Deployment
+              name: gardener-extension-admission-{{ $extShortName }}
   values:
     global:
 {{ include "admission.values" $v | indent 6 }}


### PR DESCRIPTION
The commit introduces the kustomize post-renderer in the Helm release admission template. It specifically adds a patch to replace the spec to automount the Service Account token. This modification ensures the Deployment kind 'gardener-extension-admission' has this token automatically mounted.

--

Various upstream extensions disable this property if a custom kubeconfig is set. This doesn't fit our use-case and may even be unintended in the first place. 

https://github.com/gardener/gardener-extension-provider-openstack/blob/4531784c98d2e6339bc94f296f56484bb83bfa37/charts/gardener-extension-admission-openstack/charts/runtime/templates/deployment.yaml#L29