### PR TITLE
github: set timeout of 60 minutes on the yake-install action

### DIFF
--- a/.github/workflows/yake-install.yaml
+++ b/.github/workflows/yake-install.yaml
@@ -15,6 +15,7 @@ jobs:
           - v1.27.11
           - v1.28.7
     runs-on: self-hosted
+    timeout-minutes: 60
     name: "Yake install testrun"
     steps:
       - name: Checkout source


### PR DESCRIPTION
The action usually takes 15-30 minutes. If it takes significantly longer, it gets stuck somewhere and it makes sense to run into a timeout.