### PR TITLE
Enable admission for shoot-dns-service extension

### DIFF
--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -98,6 +98,8 @@ stringData:
 
     shoot-dns-service:
       version: 1.45.1
+      admission:
+        enabled: true
       values:
         dnsControllerManager:
           deploy: true


### PR DESCRIPTION
The admission controller is required for some of its features