### PR TITLE
Revert "Enable admission for shoot-dns-service extension"

### DIFF
--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -98,8 +98,6 @@ stringData:
 
     shoot-dns-service:
       version: 1.45.1
-      admission:
-        enabled: true
       values:
         dnsControllerManager:
           deploy: true


### PR DESCRIPTION
Reverts YAKEcloud/yake#1399
We are missing netpols to make this admission work properly