### PR TITLE
Migrate ingress-nginx pod labels 

### DIFF
--- a/configuration/configuration/templates/ingress-nginx.yaml
+++ b/configuration/configuration/templates/ingress-nginx.yaml
@@ -14,9 +14,10 @@ stringData:
       admissionWebhooks:
         patch:
           labels:
+            yake.cloud/app: ingress-nginx
             yake.cloud/component: ingress-nginx
       podLabels:
-        app: nginx-ingress
+        yake.cloud/app: ingress-nginx
         component: controller
         yake.cloud/component: ingress-nginx
       service:

--- a/configuration/configuration/tests/cert-manager_test.yaml
+++ b/configuration/configuration/tests/cert-manager_test.yaml
@@ -35,7 +35,4 @@ tests:
             startupapicheck:
               image:
                 repository: myregistry.example.org/jetstack/cert-manager-ctl
-            webhook:
-              image:
-                repository: myregistry.example.org/jetstack/cert-manager-webhook
             installCRDs: true

--- a/configuration/configuration/tests/cert-manager_test.yaml
+++ b/configuration/configuration/tests/cert-manager_test.yaml
@@ -35,4 +35,7 @@ tests:
             startupapicheck:
               image:
                 repository: myregistry.example.org/jetstack/cert-manager-ctl
+            webhook:
+              image:
+                repository: myregistry.example.org/jetstack/cert-manager-webhook
             installCRDs: true

--- a/configuration/configuration/tests/ingress-nginx_test.yaml
+++ b/configuration/configuration/tests/ingress-nginx_test.yaml
@@ -14,9 +14,10 @@ tests:
               admissionWebhooks:
                 patch:
                   labels:
+                    yake.cloud/app: ingress-nginx
                     yake.cloud/component: ingress-nginx
               podLabels:
-                app: nginx-ingress
+                yake.cloud/app: ingress-nginx
                 component: controller
                 yake.cloud/component: ingress-nginx
               service:

--- a/gardener/networkpolicies/garden-kube-apiserver.yaml
+++ b/gardener/networkpolicies/garden-kube-apiserver.yaml
@@ -23,7 +23,7 @@ spec:
                 - gardener-extension-admission-shoot-dns-service
       - podSelector:
           matchLabels:
-            app: nginx-ingress
+            yake.cloud/app: ingress-nginx
             app.kubernetes.io/component: controller
             yake.cloud/component: ingress-nginx
       - podSelector:

--- a/pre-gardener/networkpolicies/garden-ingress-nginx.yaml
+++ b/pre-gardener/networkpolicies/garden-ingress-nginx.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: nginx-ingress
+      yake.cloud/app: ingress-nginx
       app.kubernetes.io/component: controller
       yake.cloud/component: ingress-nginx
   ingress:


### PR DESCRIPTION
Gardener's ingressClass `nginx-ingress-gardener` selects its pods using the `app: nginx-ingress` label. To prevent conflicts with our own ingress, we're moving away from these labels and use `yake.cloud/app: ingress-nginx` instead.