### PR TITLE
Allow ingress to talk to dashboard, identity and gardener-metrics-exporter

### DIFF
--- a/gardener/networkpolicies/garden-gardener-dashboard.yaml
+++ b/gardener/networkpolicies/garden-gardener-dashboard.yaml
@@ -9,5 +9,11 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: gardener-dashboard
+  ingress:
+    - from:
+        - podSelector:
+            - matchLabels:
+                yake.cloud/app: ingress-nginx
   policyTypes:
     - Egress
+    - Ingress

--- a/gardener/networkpolicies/garden-gardener-metrics-exporter.yaml
+++ b/gardener/networkpolicies/garden-gardener-metrics-exporter.yaml
@@ -10,5 +10,11 @@ spec:
       role: metrics-exporter
   egress:
     - {}
+  ingress:
+    - from:
+        - podSelector:
+            - matchLabels:
+                yake.cloud/app: ingress-nginx
   policyTypes:
   - Egress
+  - Ingress

--- a/gardener/networkpolicies/garden-identity.yaml
+++ b/gardener/networkpolicies/garden-identity.yaml
@@ -9,5 +9,11 @@ spec:
       app: identity
   egress:
     - {}
+  ingress:
+    - from:
+        - podSelector:
+            - matchLabels:
+                yake.cloud/app: ingress-nginx
   policyTypes:
-  - Egress
+    - Egress
+    - Ingress


### PR DESCRIPTION
Add network policies for dashboard, identity and gardener-metrics-exporter.
Changing our ingress-nginx's labels made these necessary. 

`garden-kube-apiserver` already has a suitable network policy.