### PR TITLE
github: remove kubernetes 1.26 tests

### DIFF
--- a/.github/workflows/yake-install.yaml
+++ b/.github/workflows/yake-install.yaml
@@ -15,7 +15,6 @@ jobs:
           - calico
           - cilium
         version:
-          - v1.26.14
           - v1.27.11
           - v1.28.7
     runs-on: self-hosted


### PR DESCRIPTION
Kubernetes 1.26 is EOL and not longer supported.