### PR TITLE
Fix etcd backup credentials for swift

### DIFF
--- a/configuration/configuration/templates/etcd.yaml
+++ b/configuration/configuration/templates/etcd.yaml
@@ -38,7 +38,7 @@ stringData:
           secretData:
             {{- $c := .Values.backups.credentials }}
             {{- if $c.authURL }}
-            authUrl: {{ $c.authURL }}
+            authURL: {{ $c.authURL }}
             {{- end }}
 
             {{- if $c.password }}
@@ -50,11 +50,11 @@ stringData:
             {{- end }}
 
             {{- if $c.tenantName }}
-            projectName: {{ $c.tenantName }}
+            tenantName: {{ $c.tenantName }}
             {{- end }}
 
             {{- if $c.region }}
-            regionName: {{ $c.region }}
+            region: {{ $c.region }}
             {{- end }}
 
             {{- if $c.domainName }}


### PR DESCRIPTION
Make credentials secret match expected files:

https://github.com/gardener/etcd-backup-restore/blob/17e447b2fd4cb1291e415130f70fa4017f4cc7b7/pkg/snapstore/swift_snapstore.go#L239