### PR TITLE
Add renovate regex pattern for all yaml files, track dns-controller-manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,15 @@
     {
       customType: 'regex',
       fileMatch: [
+        '[.]yaml$',
+      ],
+      matchStrings: [
+        '(?<currentValue>[^ ]+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\n'
+      ],
+    },
+    {
+      customType: 'regex',
+      fileMatch: [
         '^addons/addons/templates/dashboard.yaml$',
       ],
       datasourceTemplate: 'helm',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,7 +73,7 @@
     {
       customType: 'regex',
       fileMatch: [
-        '[.]yaml$',
+        '[.]ya?ml$',
       ],
       matchStrings: [
         '(?<currentValue>[^ ]+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\n'

--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -109,7 +109,7 @@ stringData:
 {{- else }}
             repository: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
 {{- end }}
-            tag: v0.13.3
+            tag: v0.13.3 # renovate: datasource=github-releases depName=gardener/external-dns-management
           configuration:
             cacheTtl: 300
             controllers: dnscontrollers,dnssources


### PR DESCRIPTION
Renovate any dependency that is not yet detected by renovate by adding this magic comment:

`someProperty: v1.23.4 # renovate: datasource=<datasource> depName=<depName> versioning=<versioning>`

"versioning" is optional