### PR TITLE
Allow generic s3 endpoints for entire backup stack (etcd-0, velero, shoot-etcds)

### DIFF
--- a/configuration/configuration/templates/etcd.yaml
+++ b/configuration/configuration/templates/etcd.yaml
@@ -27,9 +27,24 @@ stringData:
         backup:
           storageProvider: S3
           secretData:
-            region: {{ .Values.backups.region }}
-            accessKeyId: {{ .Values.backups.credentials.accessKeyID }}
+            region: {{ .Values.backups.region | b64enc }}
+            accessKeyID: {{ .Values.backups.credentials.accessKeyID }}
             secretAccessKey: {{ .Values.backups.credentials.secretAccessKey }}
+          storageContainer: {{ .Values.backups.bucketName }}
+{{- end }}
+{{- if eq .Values.backups.provider "S3" }}
+        backup:
+          storageProvider: S3
+          secretData:
+            region: {{ .Values.backups.region | b64enc }}
+            accessKeyID: {{ .Values.backups.credentials.accessKeyID }}
+            secretAccessKey: {{ .Values.backups.credentials.secretAccessKey }}
+            {{- if .Values.backups.endpoint }}
+            endpoint: {{ .Values.backups.endpoint | b64enc }}
+            {{- end }}
+            {{- if .Values.backups.s3ForcePathStyle }}
+            s3ForcePathStyle:  {{ .Values.backups.s3ForcePathStyle | b64enc }}
+            {{- end }}
           storageContainer: {{ .Values.backups.bucketName }}
 {{- end }}
 {{- if eq .Values.backups.provider "openstack" }}

--- a/configuration/configuration/templates/velero.yaml
+++ b/configuration/configuration/templates/velero.yaml
@@ -63,6 +63,33 @@ stringData:
           - mountPath: /target
             name: plugins
 
+{{- else if eq .Values.backups.provider "S3" }}
+    credentials:
+      useSecret: false
+    configuration:
+      extraEnvVars:
+        AWS_ACCESS_KEY_ID: {{ .Values.backups.credentials.accessKeyID | b64dec }}
+        AWS_SECRET_ACCESS_KEY: {{ .Values.backups.credentials.secretAccessKey | b64dec }}
+      backupStorageLocation:
+        - bucket: {{ .Values.backups.bucketName }}
+          provider: aws
+          prefix: velero-backup
+          config:
+            region: {{ .Values.backups.region }}
+            s3ForcePathStyle: {{ .Values.backups.s3ForcePathStyle }}
+            s3Url: {{ .Values.backups.endpoint }}
+    initContainers:
+      - name: velero-plugin-for-aws
+{{- if .Values.registryOverwrite }}
+        image: {{ include "replaceRegistry" (dict "docker.io/velero/velero-plugin-for-aws:v1.6.0" .Values.registryOverwrite) }}
+{{- else }}
+        image: velero/velero-plugin-for-aws:v1.7.0
+{{- end }}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+
 {{- else if eq .Values.backups.provider "openstack" }}
     credentials:
       useSecret: false

--- a/gardener/garden-content/templates/secret-backup-internal-seed.yaml
+++ b/gardener/garden-content/templates/secret-backup-internal-seed.yaml
@@ -7,4 +7,17 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .Values.backups.credentials | indent 2 }}
+{{- if eq .Values.backups.provider "S3" }}
+  {{- if .Values.backups.region }}
+  region: {{ .Values.backups.region | b64enc }}
+  {{- end }}
+
+  {{- if .Values.backups.endpoint }}
+  endpoint: {{ .Values.backups.endpoint | b64enc }}
+  {{- end }}
+
+  {{- if .Values.backups.s3ForcePathStyle }}
+  s3ForcePathStyle: {{ .Values.backups.s3ForcePathStyle | b64enc }}
+  {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
https://github.com/metal-stack/gardener-extension-backup-s3 is required for shoot etcd-backups to work.
Unfortunately the current implementation leads to some duplicated values in the yake-config secret since backups.credentials is [passed into garden-content verbatim](https://github.com/YAKEcloud/yake/blob/b783f0d109b55404134b6e1034d046cab6614d97/configuration/configuration/templates/garden-content.yaml#L11)
We could make https://github.com/YAKEcloud/yake/blob/main/configuration/configuration/templates/etcd.yaml and https://github.com/YAKEcloud/yake/blob/main/configuration/configuration/templates/velero.yaml read the region from backups.credentials and document the breaking change. Since etcd/seedSpec expect these in base64 and velero doesn't there's always gonna be en- or decoding somewhere.

```
stringData:
  values.yaml: |
    # [...]
    backups:
      enabled: true
      provider: S3
      bucketName: bucket name
      region: region
      endpoint: endpoint
      credentials:
        accessKeyID: base64 key id
        secretAccessKey: base64 key
        region: base64 region
        endpoint: base64 endpoint
```

Incorporating https://github.com/metal-stack/gardener-extension-backup-s3 into yake might be worth looking into.