### PR TITLE
Release provider-local image on gardener-controlplane update PRs

### DIFF
--- a/.github/workflows/build-and-push-provider-local.yaml
+++ b/.github/workflows/build-and-push-provider-local.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - renovate/*-gardener-controlplane
     paths:
       - gardener/gardener.yaml
 

--- a/.github/workflows/build-and-push-provider-local.yaml
+++ b/.github/workflows/build-and-push-provider-local.yaml
@@ -6,6 +6,10 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: Valid version tag of gardener/gardener, including leading "v". Leave empty to read version from gardener/gardener.yaml
+        required: false
   push:
     branches:
       - main
@@ -22,4 +26,6 @@ jobs:
       - name: Login to ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Build and push
+        env:
+          version: ${{ github.event.inputs.version }}
         run: ./hack/ci/yake-local/build-extension-provider-local.sh

--- a/hack/ci/yake-local/update-extension-provider-local-image.sh
+++ b/hack/ci/yake-local/update-extension-provider-local-image.sh
@@ -19,7 +19,5 @@ cd ..
 export newChart=$(tar -C gardener-upstream/charts/gardener/provider-local -czf - . | base64 -w0 -)
 export newVersion
 
-$YQ -i 'select(document_index == 0).providerConfig.values.image=("ghcr.io/yakecloud/gardener-extension-provider-local:" + env(newVersion)) ' hack/ci/yake-local/garden-content/controller-registrations.yaml
+$YQ -i 'select(document_index == 0).providerConfig.values.image=("ghcr.io/yakecloud/gardener-extension-provider-local:v" + env(newVersion)) ' hack/ci/yake-local/garden-content/controller-registrations.yaml
 $YQ -i 'select(document_index == 0).providerConfig.chart=env(newChart) ' hack/ci/yake-local/garden-content/controller-registrations.yaml
-
-


### PR DESCRIPTION
When renovate updates gardener-controlplane, the tests fail because the matching version of provider-local isn't available, yet.
This sets the release action to run on pushes to the respective branches. It also allows running the action manually.

The yake-local test run stalls until the image is available but the required 3 minutes should be well within timeouts.

Also adds a missing "v"-prefix on provider-local controller-registration updates.