### PR TITLE
Apply specific values patches to extension controllerdeployment versions v1 and v1beta1

### DIFF
--- a/gardener/extensions/templates/helmrelease-controller.yaml
+++ b/gardener/extensions/templates/helmrelease-controller.yaml
@@ -48,10 +48,20 @@ spec:
 {{- range $cur_k, $cur_v := $v.values }}
           - patch: |
               - op: add
+                path: /helm/values/{{ $cur_k }}
+                value:
+                  {{- toYaml $cur_v | nindent 18 }}
+            target:
+              version: v1
+              kind: ControllerDeployment
+              name: .*{{ $k }}.*
+          - patch: |
+              - op: add
                 path: /providerConfig/values/{{ $cur_k }}
                 value:
                   {{- toYaml $cur_v | nindent 18 }}
             target:
+              version: v1beta1
               kind: ControllerDeployment
               name: .*{{ $k }}.*
 {{- end }}


### PR DESCRIPTION
Controllerdeployment v1 expects helmchart values under /helm/values, while legacy v1beta1 expects them under /providerConfig/values. This PR aims to support both.