### PR TITLE
Don't pin shoot-dns-service's dns-controller-manager version

### DIFF
--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -109,7 +109,6 @@ stringData:
 {{- else }}
             repository: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
 {{- end }}
-            tag: v0.21.0 # renovate: datasource=github-releases depName=gardener/external-dns-management
           configuration:
             cacheTtl: 300
             controllers: dnscontrollers,dnssources


### PR DESCRIPTION
It comes with a default now, so we'll just let it use that.