### PR TITLE
Publish OCI Image of YAKE

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
           make_latest: v${{ env.RELEASE_AS_LATEST }}  # set in prepare.sh
 
   upload-oci:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     name: Upload OCI
     if: success('prepare')
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,8 @@ name: Release
 run-name: Release "${{ inputs.version || github.event.head_commit.message }}" by @${{ github.actor }}
 permissions:
   contents: write
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -59,3 +61,24 @@ jobs:
           body_path: /tmp/release-body.md
           tag_name: v${{ steps.version.outputs.version }}
           make_latest: v${{ env.RELEASE_AS_LATEST }}  # set in prepare.sh
+
+  upload-oci:
+    runs-on: self-hosted
+    name: Upload OCI
+    if: success('prepare')
+    needs:
+      - prepare
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "v${{ needs.prepare.outputs.version }}"
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Upload to harbor container registry
+        env:
+          tag: "v${{ needs.prepare.outputs.version }}"
+        run: hack/release/upload-oci.sh

--- a/hack/release/upload-oci.sh
+++ b/hack/release/upload-oci.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source hack/tools/install.sh
+
+install_flux
+
+tmpDir=$(hack/release/make-tmp-release-dir.sh OCIRepository)
+$FLUX push artifact oci://ghcr.io/yakecloud/yake:$tag \
+  --source https://github.com/yakecloud/yake --revision $tag --path="$tmpDir"

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -3,6 +3,7 @@
 TOOLS_DIR=$(dirname "$(pwd)/${BASH_SOURCE[0]}")
 TOOLS_BIN_DIR="$TOOLS_DIR/bin"
 
+FLUX="$TOOLS_BIN_DIR/flux"
 HELM="$TOOLS_BIN_DIR/helm"
 KIND="$TOOLS_BIN_DIR/kind"
 KUBECTL="$TOOLS_BIN_DIR/kubectl"
@@ -99,4 +100,16 @@ install_envsubst() {
 
 				_setVersion "$ENVSUBST" "$VERSION"
 		fi
+}
+
+install_flux() {
+  # renovate: datasource=github-releases depName=fluxcd/flux2
+  VERSION=v2.3.0
+
+  if _isStale $FLUX $VERSION; then
+    curl -L "https://github.com/fluxcd/flux2/releases/download/$VERSION/flux_${VERSION/v/}_${TOOLS_KERNEL}_$TOOLS_ARCH.tar.gz" | tar -xzm -C "$TOOLS_BIN_DIR"
+    chmod +x $FLUX
+
+    _setVersion $FLUX $VERSION
+  fi
 }


### PR DESCRIPTION
To ease running YAKE in an air-gapped environment this reintroduces OCI image releases. 
Another job was added to the existing release workflow. If "prepare" succeeds, the image is built and pushed to ghcr.io/yakecloud/yake

Partially reverts #1222