### PR TITLE
Fix marking releases as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           body_path: /tmp/release-body.md
           tag_name: v${{ steps.version.outputs.version }}
-          make_latest: v${{ env.RELEASE_AS_LATEST }}  # set in prepare.sh
+          make_latest: ${{ env.RELEASE_AS_LATEST }}  # set in prepare.sh
 
   upload-oci:
     runs-on: ubuntu-22.04

--- a/hack/release/prepare.sh
+++ b/hack/release/prepare.sh
@@ -48,7 +48,8 @@ major=$(echo "$majorAndMinor" | grep -oE '^[0-9]{1,}')
 minor=$(echo "$majorAndMinor" | grep -oE '[0-9]{1,}$')
 nextMinorBranch="release-v$major.$((minor + 1))"
 
-if [[ -e ".git/refs/heads/$nextMinorBranch" ]]; then
+# git rev-parse would also match a tag of that name, but seems like an okay solution here
+if git rev-parse --verify "origin/$nextMinorBranch" 1>/dev/null 2>&1; then
   echo "RELEASE_AS_LATEST=false" | tee -a "$GITHUB_ENV"
 else
   echo "RELEASE_AS_LATEST=true" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
Looking for the branch in .git/refs/heads/ only works if the branch was checked out before. Instead we'll use rev-parse on the remote branch name. It will produce false positives if a tag of the same name exists, but that seems like an acceptable risk here.

Also there was a copy&paste error in the workflow causing a "v" to be prepended to the make_latest boolean, making it an always truish string.