### PR TITLE
Instead of bitnami/kubectl, use gardeners ops-toolbelt image

### DIFF
--- a/pre-gardener/dnsprovider/templates/tests/dnsprovider.yaml
+++ b/pre-gardener/dnsprovider/templates/tests/dnsprovider.yaml
@@ -47,7 +47,7 @@ spec:
   serviceAccountName: {{ .Release.Name }}-test-provider-sa
   containers:
     - name: test-dnsprovider
-      image: bitnami/kubectl
+      image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:latest
       command: ['bash', '-c']
       args:
         - |

--- a/pre-gardener/issuer/templates/tests/issuer.yaml
+++ b/pre-gardener/issuer/templates/tests/issuer.yaml
@@ -47,7 +47,7 @@ spec:
   serviceAccountName: {{ .Release.Name }}-test-issuer-sa
   containers:
     - name: test-issuer
-      image: bitnami/kubectl
+      image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:latest
       command: ['bash', '-c']
       args:
         - |


### PR DESCRIPTION
which is only 5MB larger