### PR TITLE
Support "split" admission charts

### DIFF
--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -50,6 +50,7 @@ stringData:
       version: 1.49.4
       admission:
         enabled: true
+        split: false
 {{- if .Values.registryOverwrite }}
         values:
           image:
@@ -171,6 +172,8 @@ stringData:
 
     provider-alicloud:
       version: 1.58.0
+      admission:
+        enabled: true
 {{- if .Values.registryOverwrite }}
       values:
         image:

--- a/gardener/extensions/templates/helmrelease-admission.yaml
+++ b/gardener/extensions/templates/helmrelease-admission.yaml
@@ -17,7 +17,7 @@ spec:
   targetNamespace: garden
   chart:
     spec:
-      chart: {{ $k }}
+      chart: admission-{{ $extShortName }}-application
       version: {{ $v.version }}
       sourceRef:
         kind: HelmRepository
@@ -28,19 +28,6 @@ spec:
     remediation:
       retries: 3
     createNamespace: true
-  values:
-    global:
-{{ include "admission.values" . | indent 6 }}
-    gardener-extension-admission-{{ $extShortName }}:
-      enabled: true
-      application:
-        enabled: true
-  valuesFrom:
-    - kind: Secret
-      name: gardener-extension-{{ $extShortName }}-admission-tls
-      valuesKey: ca.crt
-      targetPath: global.webhookConfig.caBundle
-      optional: false
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -52,7 +39,7 @@ spec:
   targetNamespace: garden
   chart:
     spec:
-      chart: {{ $k }}
+      chart: admission-{{ $extShortName }}-runtime
       version: {{ $v.version }}
       sourceRef:
         kind: HelmRepository
@@ -75,29 +62,19 @@ spec:
             target:
               kind: Deployment
               name: gardener-extension-admission-{{ $extShortName }}
-  values:
-    global:
-{{ include "admission.values" $v | indent 6 }}
-    gardener-extension-admission-{{ $extShortName }}:
-      enabled: true
-      runtime:
-        enabled: true
   valuesFrom:
     - kind: Secret
-      name: gardener-extension-{{ $extShortName }}-admission-tls
-      valuesKey: tls.crt
-      targetPath: global.webhookConfig.tls.crt
+      name: gardener-internal-kubeconfig
+      valuesKey: value
+      targetPath: kubeconfig
       optional: false
-    - kind: Secret
-      name: gardener-extension-{{ $extShortName }}-admission-tls
-      valuesKey: tls.key
-      targetPath: global.webhookConfig.tls.key
-      optional: false
+{{- if eq ($v.admission).split false }}
     - kind: Secret
       name: gardener-internal-kubeconfig
       valuesKey: value
       targetPath: global.kubeconfig
       optional: false
+{{- end }} 
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
 * enable admission for alicloud by default
 * azure has not release a true split version yet and needs the global.kubeconfig still
 * remove all other values, tls secrets etc, this has not been required for a while already
 * tested with all extensions where we enable admission by default