### PR TITLE
Don't set repo for dns-controller-manager and use whatever upstream c…

### DIFF
--- a/configuration/configuration/templates/extensions.yaml
+++ b/configuration/configuration/templates/extensions.yaml
@@ -45,8 +45,6 @@ stringData:
       values:
         dnsControllerManager:
           deploy: true
-          image:
-            repository: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
           configuration:
             cacheTtl: 300
             controllers: dnscontrollers,dnssources


### PR DESCRIPTION
…hooses

https://github.com/gardener/gardener-extension-shoot-dns-service/commit/61193f377ac17235244535d3b5ed6bbd5a186a39 changed the path and uses versions only available in that repository